### PR TITLE
fix: pipeline, SPA routing, embed server updates, SEO improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run tests with coverage
-        run: npm run test:coverage
+        run: npm run test:ci
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarcloud-github-action@v3
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/index.html
+++ b/index.html
@@ -12,33 +12,70 @@
     />
     <meta
       name="keywords"
-      content="free movies,free tv shows,stream online,hd streaming,no sign up movies,skystream,watch movies online,watch tv shows online,4K movies,full HD"
+      content="free movies,free tv shows,stream online,hd streaming,no sign up movies,skystream,watch movies online,watch tv shows online,4K movies,full HD,streaming site"
     />
     <meta name="robots" content="index, follow" />
     <meta name="referrer" content="origin" />
+    <link rel="canonical" href="https://www.sky-stream.online/" />
 
     <!-- Content Security Policy -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://va.vercel-scripts.com https://*.vercel-scripts.com; script-src-elem 'self' 'unsafe-inline' https://www.googletagmanager.com https://va.vercel-scripts.com https://*.vercel-scripts.com; connect-src 'self' https:; frame-src 'self' https:; img-src 'self' data: https: blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;"
+      content="script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://va.vercel-scripts.com https://*.vercel-scripts.com; script-src-elem 'self' 'unsafe-inline' https://www.googletagmanager.com https://va.vercel-scripts.com https://*.vercel-scripts.com; connect-src 'self' https:; frame-src 'self' https://player.videasy.net https://vsembed.ru https://vsembed.su https://vidsrc-embed.ru https://vidsrc-embed.su https://vidsrcme.su https://vsrc.su https:; img-src 'self' data: https: blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;"
     />
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://www.sky-stream.online/" />
     <meta property="og:title" content="SkyStream | Free Movies & TV Shows Online - No Sign Up" />
     <meta
       property="og:description"
       content="Watch thousands of movies and TV shows in HD, Full HD and 4K. No sign-up required."
     />
     <meta property="og:site_name" content="SkyStream" />
+    <meta property="og:image" content="https://www.sky-stream.online/LOGO.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@SkyStream" />
     <meta name="twitter:title" content="SkyStream | Free Movies & TV Shows - No Sign Up" />
     <meta
       name="twitter:description"
       content="Stream free movies and TV shows in HD, Full HD and 4K. No registration needed."
     />
+    <meta name="twitter:image" content="https://www.sky-stream.online/LOGO.png" />
+
+    <!-- Structured Data: WebSite + SearchAction -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "SkyStream",
+        "url": "https://www.sky-stream.online",
+        "description": "Watch free movies and TV shows online in HD, Full HD and 4K. No sign-up required.",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": {
+            "@type": "EntryPoint",
+            "urlTemplate": "https://www.sky-stream.online/?q={search_term_string}"
+          },
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+
+    <!-- Structured Data: Organization -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "SkyStream",
+        "url": "https://www.sky-stream.online",
+        "logo": "https://www.sky-stream.online/LOGO.png"
+      }
+    </script>
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.sky-stream.online/sitemap.xml
+
+# Disallow API and auth paths
+Disallow: /api/
+Disallow: /auth/
+Disallow: /callback

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+        http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+  <url>
+    <loc>https://www.sky-stream.online/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://www.sky-stream.online/home</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://www.sky-stream.online/live-tv</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+</urlset>

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -9,6 +9,9 @@ import tmdbApi from '../services/tmdbApi';
 import streamingServices from '../services/streamingServices';
 import { analytics } from '../utils';
 import { parseStreamingUrl } from '../utils/urlRouting';
+import { useSeoMeta, buildMovieSchema, buildTVSeriesSchema } from '../utils/useSeoMeta';
+
+const BASE_URL = 'https://www.sky-stream.online';
 
 const Search = () => {
   const location = useLocation();
@@ -26,6 +29,39 @@ const Search = () => {
     season: null,
     episode: null,
   });
+
+  // SEO: track current deep-link content for dynamic meta tags
+  const [deepLinkContent, setDeepLinkContent] = useState(null);
+
+  // Dynamic SEO meta — updates when viewing a specific movie/show
+  useSeoMeta(
+    deepLinkContent
+      ? {
+          title:
+            deepLinkContent.type === 'movie'
+              ? `Watch ${deepLinkContent.title} Online Free`
+              : `Watch ${deepLinkContent.title} Online Free`,
+          description:
+            deepLinkContent.overview
+              ? `${deepLinkContent.overview.slice(0, 155)}...`
+              : `Stream ${deepLinkContent.title} online free in HD on SkyStream. No sign-up required.`,
+          image: deepLinkContent.poster_path
+            ? `https://image.tmdb.org/t/p/w500${deepLinkContent.poster_path}`
+            : undefined,
+          url: location.pathname,
+          type: deepLinkContent.type === 'movie' ? 'video.movie' : 'video.tv_show',
+          structuredData:
+            deepLinkContent.type === 'movie'
+              ? buildMovieSchema(deepLinkContent, `${BASE_URL}${location.pathname}`)
+              : buildTVSeriesSchema(deepLinkContent, `${BASE_URL}${location.pathname}`),
+        }
+      : {
+          title: null,
+          description:
+            'Discover and stream a vast collection of free movies and TV shows online in HD, Full HD and 4K on SkyStream. No sign-up required.',
+          url: '/',
+        }
+  );
 
   // Track page view on mount
   useEffect(() => {
@@ -47,6 +83,9 @@ const Search = () => {
             const tvData = await tmdbApi.getTVDetails(parsedUrl.id);
             content = tmdbApi.transformContent(tvData);
           }
+
+          // Update SEO meta for this specific content page
+          setDeepLinkContent({ ...content, type: parsedUrl.type });
 
           // Open modal with fetched content
           const urls = streamingServices.getAllStreamingUrls(content, {
@@ -148,6 +187,9 @@ const Search = () => {
       season: null,
       episode: null,
     });
+
+    // Reset SEO meta back to homepage defaults
+    setDeepLinkContent(null);
 
     // Navigate back if we're on a streaming URL
     if (parseStreamingUrl(location.pathname)) {

--- a/src/services/__tests__/streamingServices.test.js
+++ b/src/services/__tests__/streamingServices.test.js
@@ -5,7 +5,7 @@ describe('StreamingServices', () => {
     test('generates basic movie URL', () => {
       const url = streamingServices.getVidsrcMovieUrl(299534);
 
-      expect(url).toBe('https://vidsrc-embed.ru/embed/movie?tmdb=299534&autoplay=1');
+      expect(url).toBe('https://vsembed.ru/embed/movie?tmdb=299534&autoplay=1');
     });
 
     test('includes sub_url when provided', () => {
@@ -49,7 +49,7 @@ describe('StreamingServices', () => {
     test('generates basic TV URL without season/episode', () => {
       const url = streamingServices.getVidsrcTVUrl(1399);
 
-      expect(url).toBe('https://vidsrc-embed.ru/embed/tv?tmdb=1399&autoplay=1');
+      expect(url).toBe('https://vsembed.ru/embed/tv?tmdb=1399&autoplay=1');
     });
 
     test('includes season and episode when provided', () => {
@@ -204,7 +204,7 @@ describe('StreamingServices', () => {
 
       const urls = streamingServices.getAllStreamingUrls(content);
 
-      expect(urls.vidsrc).toContain('vidsrc-embed.ru/embed/movie');
+      expect(urls.vidsrc).toContain('vsembed.ru/embed/movie');
       expect(urls.vidsrc).toContain('tmdb=299534');
       expect(urls.videasy).toContain('videasy.net/movie/299534');
     });
@@ -217,7 +217,7 @@ describe('StreamingServices', () => {
 
       const urls = streamingServices.getAllStreamingUrls(content);
 
-      expect(urls.vidsrc).toContain('vidsrc-embed.ru/embed/tv');
+      expect(urls.vidsrc).toContain('vsembed.ru/embed/tv');
       expect(urls.vidsrc).toContain('tmdb=1399');
       expect(urls.videasy).toContain('videasy.net/tv/1399');
     });

--- a/src/services/streamingServices.js
+++ b/src/services/streamingServices.js
@@ -4,11 +4,14 @@
  */
 
 class StreamingServices {
-  // Vidsrc mirror domains (updated 2025-10-19)
-  // Use vidsrc-embed.ru as primary, with fallback mirrors
-  vidsrcDomain = 'https://vidsrc-embed.ru';
+  // Vidsrc mirror domains (updated 2026-02-23)
+  // vsembed.ru / vsembed.su are the new announced primary domains
+  // vidsrc-embed.ru / vidsrc-embed.su kept as fallbacks
+  vidsrcDomain = 'https://vsembed.ru';
 
   vidsrcMirrors = [
+    'https://vsembed.ru',
+    'https://vsembed.su',
     'https://vidsrc-embed.ru',
     'https://vidsrc-embed.su',
     'https://vidsrcme.su',
@@ -169,11 +172,13 @@ class StreamingServices {
   }
 
   /**
-   * Get Vidsrc URL for a specific mirror (0-3)
-   * Server 1 = vidsrc-embed.ru (index 0)
-   * Server 2 = vidsrc-embed.su (index 1)
-   * Server 3 = vidsrcme.su (index 2)
-   * Server 4 = vsrc.su (index 3)
+   * Get Vidsrc URL for a specific mirror (0-5)
+   * Server 1 = vsembed.ru (index 0) — new primary
+   * Server 2 = vsembed.su (index 1) — new mirror
+   * Server 3 = vidsrc-embed.ru (index 2)
+   * Server 4 = vidsrc-embed.su (index 3)
+   * Server 5 = vidsrcme.su (index 4)
+   * Server 6 = vsrc.su (index 5)
    */
   getVidsrcMirrorUrl(
     mirrorIndex,
@@ -215,38 +220,42 @@ class StreamingServices {
   }
 
   /**
-   * Get all available streaming URLs for a content item (5 servers)
-   * Servers 1-4: Vidsrc mirrors
-   * Server 5: Videasy
+   * Get all available streaming URLs for a content item (7 servers)
+   * Servers 1-6: Vidsrc mirrors (1-2 are new vsembed domains)
+   * Server 7: Videasy
    */
   getAllStreamingUrls(content, options = {}) {
     const { season, episode } = options;
     const urls = {};
 
     if (content.type === 'movie') {
-      // Servers 1-4: Vidsrc mirrors
+      // Servers 1-6: Vidsrc mirrors
       urls.server1 = this.getVidsrcMirrorUrl(0, content.id, 'movie', null, null, options);
       urls.server2 = this.getVidsrcMirrorUrl(1, content.id, 'movie', null, null, options);
       urls.server3 = this.getVidsrcMirrorUrl(2, content.id, 'movie', null, null, options);
       urls.server4 = this.getVidsrcMirrorUrl(3, content.id, 'movie', null, null, options);
-      // Server 5: Videasy
-      urls.server5 = this.getVideasyMovieUrl(content.id, options);
+      urls.server5 = this.getVidsrcMirrorUrl(4, content.id, 'movie', null, null, options);
+      urls.server6 = this.getVidsrcMirrorUrl(5, content.id, 'movie', null, null, options);
+      // Server 7: Videasy
+      urls.server7 = this.getVideasyMovieUrl(content.id, options);
 
       // Keep backward compatibility
       urls.vidsrc = urls.server1;
-      urls.videasy = urls.server5;
+      urls.videasy = urls.server7;
     } else if (content.type === 'tv') {
-      // Servers 1-4: Vidsrc mirrors
+      // Servers 1-6: Vidsrc mirrors
       urls.server1 = this.getVidsrcMirrorUrl(0, content.id, 'tv', season, episode, options);
       urls.server2 = this.getVidsrcMirrorUrl(1, content.id, 'tv', season, episode, options);
       urls.server3 = this.getVidsrcMirrorUrl(2, content.id, 'tv', season, episode, options);
       urls.server4 = this.getVidsrcMirrorUrl(3, content.id, 'tv', season, episode, options);
-      // Server 5: Videasy
-      urls.server5 = this.getVideasyTVUrl(content.id, season, episode, options);
+      urls.server5 = this.getVidsrcMirrorUrl(4, content.id, 'tv', season, episode, options);
+      urls.server6 = this.getVidsrcMirrorUrl(5, content.id, 'tv', season, episode, options);
+      // Server 7: Videasy
+      urls.server7 = this.getVideasyTVUrl(content.id, season, episode, options);
 
       // Keep backward compatibility
       urls.vidsrc = urls.server1;
-      urls.videasy = urls.server5;
+      urls.videasy = urls.server7;
     }
 
     return urls;

--- a/src/utils/useSeoMeta.js
+++ b/src/utils/useSeoMeta.js
@@ -1,0 +1,180 @@
+/**
+ * useSeoMeta — Dynamic SEO meta tag injector
+ *
+ * Updates document.title, meta description, Open Graph, Twitter Card,
+ * and JSON-LD structured data per-page without a full SSR stack.
+ *
+ * NOTE: For full crawlable SEO (Googlebot), migrate to Next.js App Router
+ * and use generateMetadata() per route. This hook covers client-side
+ * social sharing and partial bot crawling (Googlebot does execute JS).
+ */
+
+import { useEffect } from 'react';
+
+const BASE_URL = 'https://www.sky-stream.online';
+const DEFAULT_IMAGE = `${BASE_URL}/LOGO.png`;
+const SITE_NAME = 'SkyStream';
+
+/**
+ * Set or create a <meta> tag by name attribute
+ */
+function setMeta(name, content) {
+  let el = document.querySelector(`meta[name="${name}"]`);
+  if (!el) {
+    el = document.createElement('meta');
+    el.setAttribute('name', name);
+    document.head.appendChild(el);
+  }
+  el.setAttribute('content', content);
+}
+
+/**
+ * Set or create a <meta> tag by property attribute (Open Graph)
+ */
+function setMetaProperty(property, content) {
+  let el = document.querySelector(`meta[property="${property}"]`);
+  if (!el) {
+    el = document.createElement('meta');
+    el.setAttribute('property', property);
+    document.head.appendChild(el);
+  }
+  el.setAttribute('content', content);
+}
+
+/**
+ * Set or create a <link> tag by rel attribute
+ */
+function setLink(rel, href) {
+  let el = document.querySelector(`link[rel="${rel}"]`);
+  if (!el) {
+    el = document.createElement('link');
+    el.setAttribute('rel', rel);
+    document.head.appendChild(el);
+  }
+  el.setAttribute('href', href);
+}
+
+/**
+ * Inject or update a JSON-LD script block
+ */
+function setJsonLd(id, data) {
+  let el = document.querySelector(`script[data-seo-id="${id}"]`);
+  if (!el) {
+    el = document.createElement('script');
+    el.setAttribute('type', 'application/ld+json');
+    el.setAttribute('data-seo-id', id);
+    document.head.appendChild(el);
+  }
+  el.textContent = JSON.stringify(data);
+}
+
+/**
+ * @param {object} meta
+ * @param {string} meta.title       — Page title (without site name)
+ * @param {string} meta.description — Meta description
+ * @param {string} [meta.image]     — OG image URL (full)
+ * @param {string} [meta.url]       — Canonical URL path (e.g. /movie/avengers-299534)
+ * @param {'website'|'video.movie'|'video.tv_show'} [meta.type] — OG type
+ * @param {object} [meta.structuredData] — Optional JSON-LD object to inject
+ */
+export function useSeoMeta({
+  title,
+  description,
+  image = DEFAULT_IMAGE,
+  url = '/',
+  type = 'website',
+  structuredData = null,
+} = {}) {
+  useEffect(() => {
+    const fullTitle = title ? `${title} | ${SITE_NAME}` : `${SITE_NAME} | Watch Free Movies & TV Shows Online`;
+    const canonicalUrl = url.startsWith('http') ? url : `${BASE_URL}${url}`;
+
+    // Document title
+    document.title = fullTitle;
+
+    // Basic meta
+    setMeta('description', description || 'Watch free movies and TV shows in HD. No sign-up required.');
+    setLink('canonical', canonicalUrl);
+
+    // Open Graph
+    setMetaProperty('og:title', fullTitle);
+    setMetaProperty('og:description', description || '');
+    setMetaProperty('og:image', image);
+    setMetaProperty('og:url', canonicalUrl);
+    setMetaProperty('og:type', type);
+    setMetaProperty('og:site_name', SITE_NAME);
+
+    // Twitter Card
+    setMeta('twitter:title', fullTitle);
+    setMeta('twitter:description', description || '');
+    setMeta('twitter:image', image);
+    setMeta('twitter:card', 'summary_large_image');
+
+    // JSON-LD
+    if (structuredData) {
+      setJsonLd('page-ld', structuredData);
+    }
+  }, [title, description, image, url, type, structuredData]);
+}
+
+/**
+ * Convenience: build Movie structured data from TMDB content object
+ *
+ * @param {object} content — TMDB movie object
+ * @param {string} canonicalUrl
+ * @returns {object} JSON-LD Movie schema
+ */
+export function buildMovieSchema(content, canonicalUrl) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Movie',
+    name: content.title,
+    description: content.overview,
+    image: content.poster_path
+      ? `https://image.tmdb.org/t/p/w500${content.poster_path}`
+      : DEFAULT_IMAGE,
+    url: canonicalUrl,
+    datePublished: content.release_date,
+    genre: content.genres?.map(g => g.name),
+    aggregateRating: content.vote_average
+      ? {
+          '@type': 'AggregateRating',
+          ratingValue: content.vote_average.toFixed(1),
+          bestRating: '10',
+          ratingCount: content.vote_count,
+        }
+      : undefined,
+  };
+}
+
+/**
+ * Convenience: build TVSeries structured data from TMDB content object
+ *
+ * @param {object} content — TMDB TV series object
+ * @param {string} canonicalUrl
+ * @returns {object} JSON-LD TVSeries schema
+ */
+export function buildTVSeriesSchema(content, canonicalUrl) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'TVSeries',
+    name: content.name,
+    description: content.overview,
+    image: content.poster_path
+      ? `https://image.tmdb.org/t/p/w500${content.poster_path}`
+      : DEFAULT_IMAGE,
+    url: canonicalUrl,
+    datePublished: content.first_air_date,
+    genre: content.genres?.map(g => g.name),
+    aggregateRating: content.vote_average
+      ? {
+          '@type': 'AggregateRating',
+          ratingValue: content.vote_average.toFixed(1),
+          bestRating: '10',
+          ratingCount: content.vote_count,
+        }
+      : undefined,
+  };
+}
+
+export default useSeoMeta;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,36 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Sequential analysis and fixes for four reported issues.

---

### 1. Pipeline Fix (SonarQube failing)

**Root cause:** Two issues:
- The workflow used `SonarSource/sonarqube-scan-action` which is for self-hosted SonarQube servers. The project uses **SonarCloud** (`sonar.organization=skynergroup`) — the correct action is `SonarSource/sonarcloud-github-action`
- `/opt/hostedtoolcache` did not exist on the `apollo` self-hosted runner, causing the scanner binary path to fail

**Fix:**
- Switched to `sonarcloud-github-action@v3`
- Added `SONAR_HOST_URL=https://sonarcloud.io` explicitly
- Created `/opt/hostedtoolcache` on the runner with correct permissions

---

### 2. Refresh → Home (SPA Routing)

**Root cause:** No `vercel.json` configured. Vercel serves the built static files and doesn't know to fall back to `index.html` for client-side routes. On refresh of `/movie/mercy-1236153`, Vercel looks for a real file, finds nothing, and falls back to the root. The existing `_redirects` (Netlify) and `.htaccess` (Apache) files have no effect on Vercel.

**Fix:** Added `vercel.json` with a catch-all rewrite:
```json
{ "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }] }
```
Also added asset caching headers and security headers.

---

### 3. VidSrc Embed Domain Update

vsembed.ru announced new primary domains: **vsembed.ru** and **vsembed.su**

**Fix:**
- Updated `vidsrcDomain` primary to `https://vsembed.ru`
- Added `vsembed.ru` and `vsembed.su` as first two mirrors
- Retained all old mirrors as fallbacks (vidsrc-embed.ru, vidsrc-embed.su, vidsrcme.su, vsrc.su)
- Server pool expanded: **5 servers → 7 servers** (6 VidSrc mirrors + Videasy)
- Updated `frame-src` CSP to explicitly allow `vsembed.ru` and `vsembed.su`

---

### 4. SEO Improvements

SPA limitation: every route served the same static `index.html` with identical meta — Google can't distinguish `/movie/mercy-1236153` from the homepage.

**Static improvements (index.html):**
- Added `<link rel="canonical">`
- Added `og:image`, `og:url`, `twitter:image`
- Added **WebSite JSON-LD** with `SearchAction` (enables Google Sitelinks Searchbox)
- Added **Organization JSON-LD**
- Added `robots.txt` and `sitemap.xml`

**Dynamic improvements (useSeoMeta hook):**
- New `src/utils/useSeoMeta.js` — injects unique `document.title`, meta description, OG tags, and JSON-LD per content page
- Integrated in `Search.jsx`: when a movie/show URL is deep-linked, the page gets:
  - Title: `Watch {Movie Title} Online Free | SkyStream`
  - Description: TMDB overview (truncated to 155 chars)
  - OG image: TMDB poster image
  - JSON-LD: `Movie` or `TVSeries` schema with rating, genres, release date
- Resets to homepage defaults when modal closes

---

### Tech Stack Recommendation

**Do not switch to Astro.** The refresh issue is fixed by `vercel.json` — not a framework problem.

**Migrate to Next.js (App Router) — recommended for next sprint.** Reasons:
- Current SPA SEO is JS-executed only — works for Googlebot but not other crawlers
- Next.js `generateMetadata()` gives server-rendered `<head>` per route — fully crawlable
- SSG for popular movie pages (pre-rendered HTML, instant first paint)
- API routes replace any future backend needs
- Still React — ~70% of current code migrates directly
- Eliminates the routing fallback problem natively

---

### Tests

All 315 tests passing. Updated 4 test assertions to match new primary VidSrc domain (`vsembed.ru`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced SEO with dynamic metadata and structured data markup for improved search engine visibility.
  * Expanded streaming service availability through additional mirror sources for more reliable playback.

* **Chores**
  * Updated CI/CD pipeline for improved code quality scanning.
  * Added sitemap and robots configuration for enhanced site discoverability.
  * Strengthened security headers and content security policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->