### PR TITLE
feat(live-tv): disable Live TV section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/react';
-import { Search, Discover, LiveTV } from './pages';
+import { Search, Discover } from './pages';
 import { Layout } from './components';
 import { analytics } from './utils';
 
@@ -24,7 +24,7 @@ function App() {
         <Routes>
           <Route path="/" element={<Search />} />
           <Route path="/home" element={<Discover />} />
-          <Route path="/live-tv" element={<LiveTV />} />
+          <Route path="/live-tv" element={<Navigate to="/" replace />} />
           {/* Streaming URLs - render on Search page with modal handling */}
           <Route path="/movie/:slug" element={<Search />} />
           <Route path="/tv/*" element={<Search />} />

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { Home, Search, Tv } from 'lucide-react';
+import { Home, Search } from 'lucide-react';
 import ThemeToggle from './ThemeToggle';
 import './Layout.css';
 
@@ -30,13 +30,6 @@ const Layout = ({ children }) => {
             >
               <Search size={20} />
               <span>Search</span>
-            </Link>
-            <Link
-              to="/live-tv"
-              className={`layout__nav-link ${location.pathname === '/live-tv' ? 'layout__nav-link--active' : ''}`}
-            >
-              <Tv size={20} />
-              <span>Live TV</span>
             </Link>
           </nav>
 

--- a/src/components/__tests__/Layout.test.jsx
+++ b/src/components/__tests__/Layout.test.jsx
@@ -34,7 +34,7 @@ describe('Layout', () => {
 
     expect(screen.getByText('Discover')).toBeInTheDocument();
     expect(screen.getByText('Search')).toBeInTheDocument();
-    expect(screen.getByText('Live TV')).toBeInTheDocument();
+    expect(screen.queryByText('Live TV')).not.toBeInTheDocument();
   });
 
   test('renders children content', () => {
@@ -90,28 +90,5 @@ describe('Layout', () => {
 
     const searchLink = screen.getByText('Search').closest('a');
     expect(searchLink).toHaveClass('layout__nav-link--active');
-  });
-
-  test('highlights active Live TV link when on /live-tv', () => {
-    renderWithRouter(
-      <Layout>
-        <div>Content</div>
-      </Layout>,
-      { route: '/live-tv' }
-    );
-
-    const liveTVLink = screen.getByText('Live TV').closest('a');
-    expect(liveTVLink).toHaveClass('layout__nav-link--active');
-  });
-
-  test('Live TV link is functional', () => {
-    renderWithRouter(
-      <Layout>
-        <div>Content</div>
-      </Layout>
-    );
-
-    const liveTVLink = screen.getByText('Live TV').closest('a');
-    expect(liveTVLink).toHaveAttribute('href', '/live-tv');
   });
 });


### PR DESCRIPTION
Removes the Live TV section from the UI entirely.

**Changes:**
- `Layout.jsx` — Live TV nav link removed; `Tv` icon import cleaned up
- `App.jsx` — `LiveTV` page import removed; `/live-tv` route now redirects to `/`
- `Layout.test.jsx` — removed 2 stale Live TV tests; nav test updated to assert the link is absent

313 tests passing.