### PR TITLE
feat(pwa): add Progressive Web App support

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="shortcut icon" href="/favicon.ico" />
+    <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0a0a0f" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <link rel="apple-touch-icon" href="/favicon.png" />
     <title>SkyStream | Watch Free Movies & TV Shows Online - No Sign Up</title>
     <meta
       name="description"

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0a0a0f" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <link rel="apple-touch-icon" href="/favicon.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/favicon.png" />
     <title>SkyStream | Watch Free Movies & TV Shows Online - No Sign Up</title>
     <meta
       name="description"
@@ -25,7 +25,7 @@
     <!-- Content Security Policy -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://va.vercel-scripts.com https://*.vercel-scripts.com; script-src-elem 'self' 'unsafe-inline' https://www.googletagmanager.com https://va.vercel-scripts.com https://*.vercel-scripts.com; connect-src 'self' https:; frame-src 'self' https://player.videasy.net https://vsembed.ru https://vsembed.su https://vidsrc-embed.ru https://vidsrc-embed.su https://vidsrcme.su https://vsrc.su https:; img-src 'self' data: https: blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;"
+      content="script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://va.vercel-scripts.com https://*.vercel-scripts.com; worker-src 'self'; manifest-src 'self'; script-src-elem 'self' 'unsafe-inline' https://www.googletagmanager.com https://va.vercel-scripts.com https://*.vercel-scripts.com; connect-src 'self' https:; frame-src 'self' https://player.videasy.net https://vsembed.ru https://vsembed.su https://vidsrc-embed.ru https://vidsrc-embed.su https://vidsrcme.su https://vsrc.su https:; img-src 'self' data: https: blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;"
     />
 
     <!-- Open Graph / Facebook -->

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "SkyStream",
+  "short_name": "SkyStream",
+  "description": "Watch Free Movies & TV Shows Online - No Sign Up",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#0a0a0f",
+  "background_color": "#0a0a0f",
+  "icons": [
+    {
+      "src": "/favicon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/favicon.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,55 @@
+const CACHE_NAME = 'skystream-v1';
+const STATIC_ASSETS = ['/', '/favicon.png', '/favicon.ico', '/LOGO.png', '/manifest.json'];
+
+// Install: pre-cache static assets
+self.addEventListener('install', event => {
+  event.waitUntil(caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS)));
+  self.skipWaiting();
+});
+
+// Activate: clean up old caches
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then(keys =>
+        Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+      )
+  );
+  self.clients.claim();
+});
+
+// Fetch: cache-first for static assets, network-first for API/HTML
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Skip non-GET requests
+  if (request.method !== 'GET') return;
+
+  // Network-first for API calls and HTML navigation
+  if (request.mode === 'navigate' || url.pathname.startsWith('/api')) {
+    event.respondWith(
+      fetch(request)
+        .then(response => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(request, clone));
+          return response;
+        })
+        .catch(() => caches.match(request))
+    );
+    return;
+  }
+
+  // Cache-first for static assets (JS, CSS, images, fonts)
+  event.respondWith(
+    caches.match(request).then(cached => {
+      if (cached) return cached;
+      return fetch(request).then(response => {
+        const clone = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(request, clone));
+        return response;
+      });
+    })
+  );
+});

--- a/public/sw.js
+++ b/public/sw.js
@@ -7,7 +7,7 @@ self.addEventListener('install', event => {
   self.skipWaiting();
 });
 
-// Activate: clean up old caches
+// Activate: clean up old caches and claim clients
 self.addEventListener('activate', event => {
   event.waitUntil(
     caches
@@ -24,16 +24,19 @@ self.addEventListener('fetch', event => {
   const { request } = event;
   const url = new URL(request.url);
 
-  // Skip non-GET requests
+  // Skip non-GET requests and cross-origin requests
   if (request.method !== 'GET') return;
+  if (url.origin !== self.location.origin) return;
 
-  // Network-first for API calls and HTML navigation
+  // Network-first for navigation and API calls
   if (request.mode === 'navigate' || url.pathname.startsWith('/api')) {
     event.respondWith(
       fetch(request)
         .then(response => {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then(cache => cache.put(request, clone));
+          if (response.ok) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(request, clone));
+          }
           return response;
         })
         .catch(() => caches.match(request))
@@ -46,8 +49,10 @@ self.addEventListener('fetch', event => {
     caches.match(request).then(cached => {
       if (cached) return cached;
       return fetch(request).then(response => {
-        const clone = response.clone();
-        caches.open(CACHE_NAME).then(cache => cache.put(request, clone));
+        if (response.ok) {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(request, clone));
+        }
         return response;
       });
     })

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -18,3 +18,10 @@ createRoot(document.getElementById('root')).render(
     <App />
   </StrictMode>
 );
+
+// Register service worker for PWA support
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(() => {});
+  });
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -22,6 +22,8 @@ createRoot(document.getElementById('root')).render(
 // Register service worker for PWA support
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch(() => {});
+    navigator.serviceWorker.register('/sw.js').catch(err => {
+      console.warn('SW registration failed:', err);
+    });
   });
 }


### PR DESCRIPTION
Adds PWA support so users can install SkyStream on their home screen.

**Changes:**
- `public/manifest.json` — app manifest (standalone, dark theme, favicon icons)
- `public/sw.js` — service worker: cache-first for static assets, network-first for API/HTML
- `index.html` — PWA meta tags (theme-color, apple-mobile-web-app-capable, apple-touch-icon)
- `src/main.jsx` — service worker registration after app mount

Users on mobile can now 'Add to Home Screen' and get an app-like experience.