### PR TITLE
feat(player): add trailer previews on movie/TV cards

### DIFF
--- a/src/components/StreamingResultCard.css
+++ b/src/components/StreamingResultCard.css
@@ -26,6 +26,28 @@
   flex-shrink: 0;
 }
 
+.streaming-result-card__poster .trailer-button {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 5;
+  background: rgba(0, 0, 0, 0.7);
+  border: none;
+  color: #fff;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.streaming-result-card__poster .trailer-button:hover {
+  background: var(--netflix-red);
+}
+
 .streaming-result-card__image {
   width: 100%;
   height: 100%;

--- a/src/components/StreamingResultCard.jsx
+++ b/src/components/StreamingResultCard.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Play, Star, Calendar, Info } from 'lucide-react';
 import streamingServices from '../services/streamingServices';
-import TrailerButton from './TrailerButton';
+import { TrailerButton } from './TrailerButton';
 import './StreamingResultCard.css';
 
 const StreamingResultCard = ({ content, onPlay }) => {

--- a/src/components/StreamingResultCard.jsx
+++ b/src/components/StreamingResultCard.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Play, Star, Calendar, Info } from 'lucide-react';
 import streamingServices from '../services/streamingServices';
+import TrailerButton from './TrailerButton';
 import './StreamingResultCard.css';
 
 const StreamingResultCard = ({ content, onPlay }) => {
@@ -34,6 +35,7 @@ const StreamingResultCard = ({ content, onPlay }) => {
   return (
     <div className="streaming-result-card">
       <div className="streaming-result-card__poster">
+        <TrailerButton content={content} onWatch={handlePlay} />
         {posterUrl && !imageError ? (
           <img
             src={posterUrl}

--- a/src/components/TrailerButton.jsx
+++ b/src/components/TrailerButton.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Film } from 'lucide-react';
+import TrailerModal from './TrailerModal';
+
+const TrailerButton = ({ content, onWatch }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const trailer = content.videos?.find(v => v.site === 'YouTube' && v.type === 'Trailer');
+
+  if (!trailer) return null;
+
+  return (
+    <>
+      <button
+        className="trailer-button"
+        onClick={e => {
+          e.stopPropagation();
+          setIsOpen(true);
+        }}
+        title="Watch Trailer"
+      >
+        <Film size={14} />
+      </button>
+
+      <TrailerModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        onWatch={onWatch}
+        trailerKey={trailer.key}
+        title={content.title}
+      />
+    </>
+  );
+};
+
+TrailerButton.propTypes = {
+  content: PropTypes.shape({
+    title: PropTypes.string,
+    videos: PropTypes.arrayOf(
+      PropTypes.shape({
+        key: PropTypes.string,
+        site: PropTypes.string,
+        type: PropTypes.string,
+      })
+    ),
+  }).isRequired,
+  onWatch: PropTypes.func,
+};
+
+export default TrailerButton;

--- a/src/components/TrailerButton.jsx
+++ b/src/components/TrailerButton.jsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Film } from 'lucide-react';
-import TrailerModal from './TrailerModal';
+import { TrailerModal } from './TrailerModal';
 
-const TrailerButton = ({ content, onWatch }) => {
+export const TrailerButton = ({ content, onWatch }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const trailer = content.videos?.find(v => v.site === 'YouTube' && v.type === 'Trailer');
@@ -47,5 +47,3 @@ TrailerButton.propTypes = {
   }).isRequired,
   onWatch: PropTypes.func,
 };
-
-export default TrailerButton;

--- a/src/components/TrailerModal.css
+++ b/src/components/TrailerModal.css
@@ -1,0 +1,91 @@
+.trailer-modal__overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 2rem;
+}
+
+.trailer-modal__content {
+  position: relative;
+  width: 100%;
+  max-width: 900px;
+  background: var(--bg-primary);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.trailer-modal__close-btn {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  z-index: 10;
+  background: rgba(0, 0, 0, 0.6);
+  border: none;
+  color: var(--text-primary);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.trailer-modal__close-btn:hover {
+  background: rgba(0, 0, 0, 0.8);
+}
+
+.trailer-modal__video-container {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%; /* 16:9 */
+}
+
+.trailer-modal__video-container iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.trailer-modal__footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.trailer-modal__watch-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1.5rem;
+  background: var(--netflix-red);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.trailer-modal__watch-btn:hover {
+  opacity: 0.85;
+}
+
+@media (max-width: 640px) {
+  .trailer-modal__overlay {
+    padding: 1rem;
+  }
+}

--- a/src/components/TrailerModal.jsx
+++ b/src/components/TrailerModal.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { X, Play } from 'lucide-react';
 import './TrailerModal.css';
 
-const TrailerModal = ({ isOpen, onClose, onWatch, trailerKey, title }) => {
+export const TrailerModal = ({ isOpen, onClose, onWatch, trailerKey, title }) => {
   if (!isOpen) return null;
 
   return (
@@ -41,5 +41,3 @@ TrailerModal.propTypes = {
   trailerKey: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
 };
-
-export default TrailerModal;

--- a/src/components/TrailerModal.jsx
+++ b/src/components/TrailerModal.jsx
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types';
+import { X, Play } from 'lucide-react';
+import './TrailerModal.css';
+
+const TrailerModal = ({ isOpen, onClose, onWatch, trailerKey, title }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="trailer-modal__overlay" onClick={onClose}>
+      <div className="trailer-modal__content" onClick={e => e.stopPropagation()}>
+        <button className="trailer-modal__close-btn" onClick={onClose} aria-label="Close trailer">
+          <X size={20} />
+        </button>
+
+        <div className="trailer-modal__video-container">
+          <iframe
+            src={`https://www.youtube.com/embed/${trailerKey}?autoplay=1`}
+            title={`${title} Trailer`}
+            allow="autoplay; encrypted-media"
+            allowFullScreen
+          />
+        </div>
+
+        {onWatch && (
+          <div className="trailer-modal__footer">
+            <button className="trailer-modal__watch-btn" onClick={onWatch}>
+              <Play size={18} />
+              Watch Now
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+TrailerModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onWatch: PropTypes.func,
+  trailerKey: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+};
+
+export default TrailerModal;

--- a/src/services/tmdbApi.js
+++ b/src/services/tmdbApi.js
@@ -400,6 +400,7 @@ class TMDBApi {
       original_language: item.original_language,
       original_title: item.original_title || item.original_name,
       original_name: item.original_name || item.original_title,
+      videos: item.videos?.results || [],
       type: isMovie ? 'movie' : isTVShow ? 'tv' : 'unknown',
       media_type: item.media_type || (isMovie ? 'movie' : 'tv'),
     };


### PR DESCRIPTION
Adds trailer preview functionality — users can watch the YouTube trailer before streaming.

**Changes:**
- `TrailerModal.jsx/css` — YouTube embed modal with autoplay, dark overlay, Watch Now button
- `TrailerButton.jsx` — Film icon overlay on cards, only renders when a YouTube trailer exists
- `StreamingResultCard.jsx` — renders TrailerButton top-left on poster
- `tmdbApi.js` — passes `videos` array through `transformContent()` so trailer data is available

Increases engagement and time-on-site by letting users preview content before committing to stream.