### PR TITLE
feat(player): improved multi-server selector UI

### DIFF
--- a/src/components/StreamingPlayerModal.css
+++ b/src/components/StreamingPlayerModal.css
@@ -71,55 +71,106 @@
   transition: color 0.3s ease;
 }
 
-/* Server Selector */
-.streaming-player-modal__server-selector {
+/* Server Bar */
+.streaming-player-modal__server-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  background: var(--input-bg);
+  border-bottom: 1px solid var(--border-color);
+  transition:
+    background 0.3s ease,
+    border-color 0.3s ease;
+}
+
+.streaming-player-modal__server-pills {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  margin-top: 0.5rem;
+  overflow-x: auto;
+  max-width: 100%;
+  padding-bottom: 2px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(229, 9, 20, 0.3) transparent;
+  -webkit-overflow-scrolling: touch;
 }
 
-.streaming-player-modal__server-selector label {
-  font-size: 0.9rem;
-  color: var(--text-primary);
-  white-space: nowrap;
+.streaming-player-modal__server-pills::-webkit-scrollbar {
+  height: 4px;
+}
+
+.streaming-player-modal__server-pills::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.streaming-player-modal__server-pills::-webkit-scrollbar-thumb {
+  background: rgba(229, 9, 20, 0.3);
+  border-radius: 2px;
+}
+
+.streaming-player-modal__server-pill {
+  flex-shrink: 0;
+  padding: 0.4rem 1rem;
+  border-radius: 9999px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 0.85rem;
   font-weight: 500;
-  transition: color 0.3s ease;
-}
-
-.streaming-player-modal__server-select {
-  background: linear-gradient(135deg, rgba(229, 9, 20, 0.1), rgba(229, 9, 20, 0.05));
-  border: 1px solid rgba(229, 9, 20, 0.3);
-  border-radius: 8px;
-  color: var(--text-primary);
-  padding: 0.5rem 0.75rem;
-  font-size: 0.9rem;
-  min-width: 160px;
   cursor: pointer;
-  transition: all 0.3s ease;
-  font-weight: 500;
-  box-shadow: 0 2px 8px rgba(229, 9, 20, 0.1);
+  white-space: nowrap;
+  transition:
+    background 0.25s ease,
+    color 0.25s ease,
+    border-color 0.25s ease,
+    box-shadow 0.25s ease,
+    transform 0.15s ease;
 }
 
-.streaming-player-modal__server-select:hover {
-  background: linear-gradient(135deg, rgba(229, 9, 20, 0.15), rgba(229, 9, 20, 0.08));
-  border-color: rgba(229, 9, 20, 0.5);
-  box-shadow: 0 4px 12px rgba(229, 9, 20, 0.2);
+.streaming-player-modal__server-pill:hover {
+  background: rgba(229, 9, 20, 0.1);
+  border-color: rgba(229, 9, 20, 0.4);
+  color: var(--text-primary);
   transform: translateY(-1px);
 }
 
-.streaming-player-modal__server-select:focus {
-  outline: none;
-  background: linear-gradient(135deg, rgba(229, 9, 20, 0.2), rgba(229, 9, 20, 0.1));
+.streaming-player-modal__server-pill--active {
+  background: var(--netflix-red);
   border-color: var(--netflix-red);
-  box-shadow: 0 0 0 3px rgba(229, 9, 20, 0.3);
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(229, 9, 20, 0.4);
 }
 
-.streaming-player-modal__server-select option {
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  padding: 0.5rem;
-  font-weight: 500;
+.streaming-player-modal__server-pill--active:hover {
+  background: var(--netflix-red);
+  border-color: var(--netflix-red);
+  color: #fff;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(229, 9, 20, 0.5);
+}
+
+.streaming-player-modal__server-pill:focus-visible {
+  outline: 2px solid var(--netflix-red);
+  outline-offset: 2px;
+}
+
+.streaming-player-modal__server-hint {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  transition: color 0.3s ease;
+}
+
+/* Iframe loading transition */
+.streaming-player-modal__iframe--loading {
+  opacity: 0.3;
+  transition: opacity 0.3s ease;
+}
+
+.streaming-player-modal__iframe--loaded {
+  opacity: 1;
+  transition: opacity 0.3s ease;
 }
 
 /* Episode Controls */
@@ -282,17 +333,13 @@
     font-size: 1.1rem;
   }
 
-  .streaming-player-modal__server-selector {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.25rem;
-    margin-top: 0.25rem;
+  .streaming-player-modal__server-bar {
+    padding: 0.5rem 1rem;
   }
 
-  .streaming-player-modal__server-select {
-    min-width: 140px;
+  .streaming-player-modal__server-pill {
+    padding: 0.35rem 0.75rem;
     font-size: 0.8rem;
-    padding: 0.4rem 0.6rem;
   }
 
   .streaming-player-modal__episode-controls {

--- a/src/components/StreamingPlayerModal.jsx
+++ b/src/components/StreamingPlayerModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { X, ExternalLink, Download } from 'lucide-react';
 import streamingServices from '../services/streamingServices';
@@ -6,11 +6,41 @@ import tmdbApi from '../services/tmdbApi';
 import { generateMovieUrl, generateTVUrl, updateBrowserUrl } from '../utils/urlRouting';
 import './StreamingPlayerModal.css';
 
+const STORAGE_KEY = 'skystream-preferred-server';
+
+const SERVER_OPTIONS = [
+  { key: 'server1', label: 'Server 1' },
+  { key: 'server2', label: 'Server 2' },
+  { key: 'server3', label: 'Server 3' },
+  { key: 'server4', label: 'Server 4' },
+  { key: 'server5', label: 'Server 5' },
+  { key: 'server6', label: 'Server 6' },
+  { key: 'server7', label: 'Videasy' },
+];
+
+const getPreferredServer = () => {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved && SERVER_OPTIONS.some(s => s.key === saved)) return saved;
+  } catch {
+    /* ignore */
+  }
+  return 'server1';
+};
+
+const savePreferredServer = key => {
+  try {
+    localStorage.setItem(STORAGE_KEY, key);
+  } catch {
+    /* ignore */
+  }
+};
+
 const StreamingPlayerModal = ({
   isOpen,
   onClose,
   content,
-  platform,
+  platform: _platform,
   embedUrl,
   contentType = 'movie',
   season = null,
@@ -20,9 +50,10 @@ const StreamingPlayerModal = ({
   const [selectedSeason, setSelectedSeason] = useState(season || 1);
   const [selectedEpisode, setSelectedEpisode] = useState(episode || 1);
   const [currentEmbedUrl, setCurrentEmbedUrl] = useState(embedUrl);
-  const [selectedPlatform, setSelectedPlatform] = useState(platform || 'server1');
+  const [selectedPlatform, setSelectedPlatform] = useState(() => getPreferredServer());
   const [seasonsData, setSeasonsData] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [iframeSwitching, setIframeSwitching] = useState(false);
 
   // Sync state with props when they change (e.g., from deep linking)
   useEffect(() => {
@@ -50,6 +81,17 @@ const StreamingPlayerModal = ({
     }
   };
 
+  // Handle server switch with loading transition
+  const handleServerSwitch = useCallback(
+    serverKey => {
+      if (serverKey === selectedPlatform) return;
+      setIframeSwitching(true);
+      setSelectedPlatform(serverKey);
+      savePreferredServer(serverKey);
+    },
+    [selectedPlatform]
+  );
+
   // Update embed URL when season/episode/platform changes
   useEffect(() => {
     if (content?.id && selectedPlatform) {
@@ -58,18 +100,32 @@ const StreamingPlayerModal = ({
         episode: selectedEpisode,
       });
 
-      // Support both old format (vidsrc/videasy) and new format (server1-5)
-      if (selectedPlatform?.startsWith('server')) {
+      // Support both new format (server1-7) and legacy keys
+      if (urls[selectedPlatform]) {
         setCurrentEmbedUrl(urls[selectedPlatform]);
       } else if (selectedPlatform === 'vidsrc') {
         setCurrentEmbedUrl(urls.server1);
       } else if (selectedPlatform === 'videasy') {
-        setCurrentEmbedUrl(urls.server5);
+        setCurrentEmbedUrl(urls.server7);
       }
     } else {
       setCurrentEmbedUrl(embedUrl);
     }
-  }, [selectedSeason, selectedEpisode, selectedPlatform, contentType, content, embedUrl]);
+
+    // Clear switching state after a brief delay
+    if (iframeSwitching) {
+      const timer = setTimeout(() => setIframeSwitching(false), 300);
+      return () => clearTimeout(timer);
+    }
+  }, [
+    selectedSeason,
+    selectedEpisode,
+    selectedPlatform,
+    contentType,
+    content,
+    embedUrl,
+    iframeSwitching,
+  ]);
 
   // Fetch seasons data from TMDB when modal opens for TV content
   useEffect(() => {
@@ -266,21 +322,6 @@ const StreamingPlayerModal = ({
         <div className="streaming-player-modal__header">
           <div className="streaming-player-modal__title">
             <h2>{content?.title}</h2>
-            <div className="streaming-player-modal__server-selector">
-              <label htmlFor="server-select">Server:</label>
-              <select
-                id="server-select"
-                value={selectedPlatform}
-                onChange={e => setSelectedPlatform(e.target.value)}
-                className="streaming-player-modal__server-select"
-              >
-                <option value="server1">Server 1 (Vidsrc)</option>
-                <option value="server2">Server 2 (Vidsrc)</option>
-                <option value="server3">Server 3 (Vidsrc)</option>
-                <option value="server4">Server 4 (Vidsrc)</option>
-                <option value="server5">Server 5 (Videasy)</option>
-              </select>
-            </div>
           </div>
 
           {/* Season and Episode Selectors for TV Series */}
@@ -375,11 +416,29 @@ const StreamingPlayerModal = ({
           </div>
         </div>
 
+        <div className="streaming-player-modal__server-bar">
+          <div className="streaming-player-modal__server-pills">
+            {SERVER_OPTIONS.map(({ key, label }) => (
+              <button
+                key={key}
+                type="button"
+                className={`streaming-player-modal__server-pill${selectedPlatform === key ? ' streaming-player-modal__server-pill--active' : ''}`}
+                onClick={() => handleServerSwitch(key)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <span className="streaming-player-modal__server-hint">
+            Video not loading? Try another server
+          </span>
+        </div>
+
         <div className="streaming-player-modal__player">
           <iframe
             src={currentEmbedUrl}
-            title={`${content?.title} - ${platform}`}
-            className="streaming-player-modal__iframe"
+            title={`${content?.title} - ${selectedPlatform}`}
+            className={`streaming-player-modal__iframe ${iframeSwitching ? 'streaming-player-modal__iframe--loading' : 'streaming-player-modal__iframe--loaded'}`}
             allowFullScreen
             allow="encrypted-media; autoplay; fullscreen"
             referrerPolicy="origin"
@@ -411,6 +470,8 @@ StreamingPlayerModal.propTypes = {
     'server3',
     'server4',
     'server5',
+    'server6',
+    'server7',
     'vidsrc',
     'videasy',
   ]).isRequired,

--- a/src/components/StreamingPlayerModal.jsx
+++ b/src/components/StreamingPlayerModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { X, ExternalLink, Download } from 'lucide-react';
 import streamingServices from '../services/streamingServices';
@@ -18,12 +18,17 @@ const SERVER_OPTIONS = [
   { key: 'server7', label: 'Videasy' },
 ];
 
-const getPreferredServer = () => {
+const getPreferredServer = fallbackKey => {
   try {
     const saved = localStorage.getItem(STORAGE_KEY);
     if (saved && SERVER_OPTIONS.some(s => s.key === saved)) return saved;
   } catch {
     /* ignore */
+  }
+  if (fallbackKey) {
+    if (SERVER_OPTIONS.some(s => s.key === fallbackKey)) return fallbackKey;
+    if (fallbackKey === 'videasy') return 'server7';
+    if (fallbackKey === 'vidsrc') return 'server1';
   }
   return 'server1';
 };
@@ -50,7 +55,7 @@ const StreamingPlayerModal = ({
   const [selectedSeason, setSelectedSeason] = useState(season || 1);
   const [selectedEpisode, setSelectedEpisode] = useState(episode || 1);
   const [currentEmbedUrl, setCurrentEmbedUrl] = useState(embedUrl);
-  const [selectedPlatform, setSelectedPlatform] = useState(() => getPreferredServer());
+  const [selectedPlatform, setSelectedPlatform] = useState(() => getPreferredServer(_platform));
   const [seasonsData, setSeasonsData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [iframeSwitching, setIframeSwitching] = useState(false);
@@ -82,15 +87,12 @@ const StreamingPlayerModal = ({
   };
 
   // Handle server switch with loading transition
-  const handleServerSwitch = useCallback(
-    serverKey => {
-      if (serverKey === selectedPlatform) return;
-      setIframeSwitching(true);
-      setSelectedPlatform(serverKey);
-      savePreferredServer(serverKey);
-    },
-    [selectedPlatform]
-  );
+  const handleServerSwitch = serverKey => {
+    if (serverKey === selectedPlatform) return;
+    setIframeSwitching(true);
+    setSelectedPlatform(serverKey);
+    savePreferredServer(serverKey);
+  };
 
   // Update embed URL when season/episode/platform changes
   useEffect(() => {

--- a/src/components/__tests__/StreamingPlayerModal.test.jsx
+++ b/src/components/__tests__/StreamingPlayerModal.test.jsx
@@ -134,8 +134,8 @@ describe('StreamingPlayerModal', () => {
       />
     );
 
-    expect(screen.getByText('Server 1 (Vidsrc)')).toBeInTheDocument();
-    expect(screen.getByText('Server 2 (Vidsrc)')).toBeInTheDocument();
+    expect(screen.getByText('Server 1')).toBeInTheDocument();
+    expect(screen.getByText('Server 2')).toBeInTheDocument();
   });
 
   test('switches platform when Server 2 is clicked', () => {
@@ -149,7 +149,7 @@ describe('StreamingPlayerModal', () => {
       />
     );
 
-    const server2Button = screen.getByText('Server 2 (Vidsrc)');
+    const server2Button = screen.getByText('Server 2');
     fireEvent.click(server2Button);
 
     expect(streamingServices.getAllStreamingUrls).toHaveBeenCalled();
@@ -339,34 +339,38 @@ describe('StreamingPlayerModal', () => {
   });
 
   describe('Server Selection Coverage', () => {
-    test('should render all 5 server options', () => {
+    test('should render all 7 server options', () => {
       render(<StreamingPlayerModal isOpen={true} onClose={jest.fn()} content={mockContent} />);
-      expect(screen.getByText('Server 1 (Vidsrc)')).toBeInTheDocument();
-      expect(screen.getByText('Server 2 (Vidsrc)')).toBeInTheDocument();
-      expect(screen.getByText('Server 3 (Vidsrc)')).toBeInTheDocument();
-      expect(screen.getByText('Server 4 (Vidsrc)')).toBeInTheDocument();
-      expect(screen.getByText('Server 5 (Videasy)')).toBeInTheDocument();
+      expect(screen.getByText('Server 1')).toBeInTheDocument();
+      expect(screen.getByText('Server 2')).toBeInTheDocument();
+      expect(screen.getByText('Server 3')).toBeInTheDocument();
+      expect(screen.getByText('Server 4')).toBeInTheDocument();
+      expect(screen.getByText('Server 5')).toBeInTheDocument();
+      expect(screen.getByText('Server 6')).toBeInTheDocument();
+      expect(screen.getByText('Videasy')).toBeInTheDocument();
     });
 
     test('should update iframe when server changes', async () => {
       streamingServices.getAllStreamingUrls = jest.fn(() => ({
-        server1: 'https://vidsrc-embed.ru/embed/movie?tmdb=1',
-        server2: 'https://vidsrc-embed.su/embed/movie?tmdb=1',
-        server3: 'https://vidsrcme.su/embed/movie?tmdb=1',
-        server4: 'https://vsrc.su/embed/movie?tmdb=1',
-        server5: 'https://player.videasy.net/embed/movie?tmdb=1',
+        server1: 'https://vsembed.ru/embed/movie?tmdb=1',
+        server2: 'https://vsembed.su/embed/movie?tmdb=1',
+        server3: 'https://vidsrc-embed.ru/embed/movie?tmdb=1',
+        server4: 'https://vidsrc-embed.su/embed/movie?tmdb=1',
+        server5: 'https://vidsrcme.su/embed/movie?tmdb=1',
+        server6: 'https://vsrc.su/embed/movie?tmdb=1',
+        server7: 'https://player.videasy.net/movie/1',
       }));
 
-      const { container } = render(
-        <StreamingPlayerModal isOpen={true} onClose={jest.fn()} content={mockContent} />
-      );
+      render(<StreamingPlayerModal isOpen={true} onClose={jest.fn()} content={mockContent} />);
 
-      const select = container.querySelector('select');
-      fireEvent.change(select, { target: { value: 'server2' } });
+      // Click Server 2 button to switch
+      const server2Button = screen.getByText('Server 2');
+      fireEvent.click(server2Button);
 
       await waitFor(() => {
-        const iframe = container.querySelector('iframe');
-        expect(iframe.src).toContain('vidsrc-embed.su');
+        const iframes = document.querySelectorAll('iframe');
+        const playerIframe = Array.from(iframes).find(f => f.src.includes('vsembed'));
+        expect(playerIframe).toBeTruthy();
       });
     });
   });
@@ -396,9 +400,11 @@ describe('StreamingPlayerModal', () => {
       expect(heading).toBeInTheDocument();
     });
 
-    test('should have accessible server selector label', () => {
+    test('should have accessible server selector', () => {
       render(<StreamingPlayerModal isOpen={true} onClose={jest.fn()} content={mockContent} />);
-      expect(screen.getByLabelText('Server:')).toBeInTheDocument();
+      // Server selector uses pill buttons with role=button
+      expect(screen.getByText('Server 1')).toBeInTheDocument();
+      expect(screen.getByText('Videasy')).toBeInTheDocument();
     });
 
     test('should have accessible season selector for TV shows', async () => {


### PR DESCRIPTION
Redesigns the server selector in the player modal to reduce abandonment when an embed is down.

**Changes:**
- Prominent pill-button bar above the iframe (Server 1-6 + Videasy)
- Active server highlighted with accent colour
- 'Video not loading? Try another server' helper text
- Last-used server persisted in localStorage across sessions
- Horizontally scrollable on mobile
- Smooth opacity transition on server switch

Users can now switch servers with one tap instead of hunting through a dropdown.