### PR TITLE
fix(config): fallback to VITE_ env vars - site is broken

### DIFF
--- a/src/services/tmdbServer.js
+++ b/src/services/tmdbServer.js
@@ -3,8 +3,11 @@
  * This runs on the server only (no browser APIs)
  */
 
-const TMDB_API_KEY = process.env.NEXT_PUBLIC_TMDB_API_KEY || '';
-const TMDB_BASE_URL = process.env.NEXT_PUBLIC_TMDB_BASE_URL || 'https://api.themoviedb.org/3';
+const TMDB_API_KEY = process.env.NEXT_PUBLIC_TMDB_API_KEY || process.env.VITE_TMDB_API_KEY || '';
+const TMDB_BASE_URL =
+  process.env.NEXT_PUBLIC_TMDB_BASE_URL ||
+  process.env.VITE_TMDB_BASE_URL ||
+  'https://api.themoviedb.org/3';
 
 export async function fetchMovieDetails(movieId) {
   try {

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -5,7 +5,14 @@
 
 // Helper function to get environment variable with fallback
 const getEnvVar = (key, defaultValue = '') => {
-  return process.env[key] || defaultValue;
+  // Check NEXT_PUBLIC_ key first, then fall back to VITE_ equivalent
+  const value = process.env[key];
+  if (value) return value;
+  if (key.startsWith('NEXT_PUBLIC_')) {
+    const viteKey = key.replace('NEXT_PUBLIC_', 'VITE_');
+    if (process.env[viteKey]) return process.env[viteKey];
+  }
+  return defaultValue;
 };
 
 // Helper function to get boolean environment variable


### PR DESCRIPTION
**HOTFIX** — Site is down because TMDB API key is set as `VITE_TMDB_API_KEY` in Vercel but the code now reads `NEXT_PUBLIC_TMDB_API_KEY`.

Adds fallback: `getEnvVar` checks `NEXT_PUBLIC_*` first, then `VITE_*`.

Sir: after merging, please also rename the env vars in Vercel settings:
`VITE_TMDB_API_KEY` → `NEXT_PUBLIC_TMDB_API_KEY` (and any other VITE_ vars)