### PR TITLE
feat(seo): cleanup and GitHub attribution [DEV-85]

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -93,6 +93,23 @@ export default function RootLayout({ children }) {
               name: 'SkyStream',
               url: 'https://www.sky-stream.online',
               logo: 'https://www.sky-stream.online/LOGO.png',
+              founder: [
+                {
+                  '@type': 'Person',
+                  name: 'Yashiel Sookdeo',
+                  url: 'https://github.com/yashiels',
+                },
+                {
+                  '@type': 'Person',
+                  name: 'Mpho Ndlela',
+                  url: 'https://github.com/MphoCodes',
+                },
+              ],
+              sameAs: [
+                'https://github.com/skynergroup',
+                'https://github.com/yashiels',
+                'https://github.com/MphoCodes',
+              ],
             }),
           }}
         />

--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -131,6 +131,23 @@
   opacity: 0.7;
 }
 
+.layout__footer-credits {
+  margin-top: 1rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.layout__footer-credits a {
+  color: var(--text-primary);
+  text-decoration: none;
+  transition: opacity 0.2s ease;
+}
+
+.layout__footer-credits a:hover {
+  opacity: 0.7;
+  text-decoration: underline;
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .layout__header {

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,14 +1,21 @@
 'use client';
 
+import { useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import PropTypes from 'prop-types';
 import { Home, Search } from 'lucide-react';
 import ThemeToggle from './ThemeToggle';
+import analytics from '../utils/analytics';
 import './Layout.css';
 
 const Layout = ({ children }) => {
   const pathname = usePathname();
+
+  // Initialize analytics on mount
+  useEffect(() => {
+    analytics.init();
+  }, []);
 
   return (
     <div className="layout">
@@ -52,6 +59,34 @@ const Layout = ({ children }) => {
           <p className="layout__footer-disclaimer">
             Content provided by third-party services. We do not host any content.
           </p>
+          <div className="layout__footer-credits">
+            <p>
+              This site was made by{' '}
+              <a
+                href="https://github.com/skynergroup"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Skyner Group
+              </a>
+              , by devs{' '}
+              <a
+                href="https://github.com/yashiels"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Yashiel Sookdeo
+              </a>
+              {' '}and{' '}
+              <a
+                href="https://github.com/MphoCodes"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Mpho Ndlela
+              </a>
+            </p>
+          </div>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
## Summary

- Add footer credits linking to Skyner Group, Yashiel Sookdeo, and Mpho Ndlela (drives foot traffic to GitHub)
- Update Organization schema in `app/layout.jsx` with founder info and sameAs links
  - Added Yashiel Sookdeo and Mpho Ndlela as founders
  - Added sameAs links to skynergroup, yashiels, and MphoCodes GitHub accounts
- Initialize analytics on mount (was never called — trackPageView/trackEvent calls silently failed)
- Remove dead `src/pages-legacy` folder (unused leftover code)

Closes DEV-85

Co-Authored-By: Yashiel Sookdeo <yashiel@skyner.co.za>
Co-Authored-By: Mpho Ndlela <mpho.c.ndlela@gmail.com>