### PR TITLE
ci(skystream): switch to GitHub-hosted runners with caching #74

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,34 +1,26 @@
-name: Build
+name: CI
 
 on:
   push:
-    branches:
-      - production
+    branches: [production]
   pull_request:
-    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     name: Build & Test
-    runs-on: [self-hosted, Linux, X64, astra]
-
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Format check
-        run: npm run format:check
-
-      - name: Build
-        run: npm run build
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format:check
+      - run: npm run build


### PR DESCRIPTION
Switches CI from self-hosted runners to `ubuntu-latest`. Adds npm caching and concurrency.

Closes #74

Co-authored-by: Yashiel Sookdeo <yashiel@skyner.co.za>