### PR TITLE
chore(ci): use self-hosted cosmos runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build:
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: cosmos
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Switch CI runner from `ubuntu-latest` (GitHub-hosted) to `cosmos` (self-hosted) to ensure all builds run on the skynergroup self-hosted runner fleet

## Test plan
- [ ] Verify CI runs on cosmos runner
- [ ] Confirm Dependabot PRs trigger CI on self-hosted runner