### PR TITLE
fix(player): remove iframe sandbox attribute breaking third-party embeds

### DIFF
--- a/apps/web/src/components/StreamingPlayerModal.jsx
+++ b/apps/web/src/components/StreamingPlayerModal.jsx
@@ -293,7 +293,6 @@ const StreamingPlayerModal = ({
             referrerPolicy="origin"
             style={{ border: 'none' }}
             loading="lazy"
-            sandbox="allow-scripts allow-same-origin allow-presentation allow-fullscreen allow-popups"
           />
         </div>
 


### PR DESCRIPTION
### **User description**
## Problem

Third-party embed players show an **Iframe Sandbox Detected** error on the Vercel deployment. The `sandbox` attribute on the iframe in `StreamingPlayerModal` blocks capabilities various servers need (form submissions, popups, etc).

## Root Cause

The iframe had:
```
sandbox="allow-scripts allow-same-origin allow-presentation allow-fullscreen allow-popups"
```

Missing `allow-forms` and `allow-popups-to-escape-sandbox` at minimum, but different third-party servers require different capabilities — making it a whack-a-mole problem.

## Fix

Remove the `sandbox` attribute entirely. `allow-scripts` + `allow-same-origin` together already neutralise most of the sandbox's protection, so the attribute gave a false sense of security while breaking real functionality.

## Verification

- All 31 existing `StreamingPlayerModal` tests pass
- Single-line deletion, no functional logic changes

Closes #81


___

### **PR Type**
Bug fix


___

### **Description**
- Remove `sandbox` attribute from iframe

- Fix third-party embed player failures

- Eliminate false security from sandbox

- Restore form submissions and popups


___

### Diagram Walkthrough


```mermaid
flowchart LR
  iframe["iframe element"] -- "remove sandbox attribute" --> nosandbox["iframe without sandbox"]
  nosandbox -- "allows" --> forms["form submissions"]
  nosandbox -- "allows" --> popups["popup escapes"]
  nosandbox -- "fixes" --> thirdparty["third-party players"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StreamingPlayerModal.jsx</strong><dd><code>Remove iframe sandbox attribute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/StreamingPlayerModal.jsx

<ul><li>Removed <code>sandbox</code> attribute from the iframe element<br> <li> Fixes third-party embed players blocked by sandbox restrictions<br> <li> Eliminates false security since <code>allow-scripts</code> + <code>allow-same-origin</code> <br>already neutralized protection</ul>


</details>


  </td>
  <td><a href="https://github.com/skynergroup/skystream/pull/82/files#diff-4b1f3500bc2364c4c917b69295dfddf1be17fed9dfd6e0b1dc69d8ef5536be8d">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

