### PR TITLE
fix(ci): correct Gradle node_modules paths for monorepo layout

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -86,7 +86,7 @@ jobs:
           node-version: '22'
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
-apply from: file("../../../node_modules/react-native-vector-icons/fonts.gradle")
+apply from: file("../../../../node_modules/react-native-vector-icons/fonts.gradle")
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
 /**
@@ -11,13 +11,13 @@ apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.grad
 react {
     /* Folders */
     //   The root of your project, i.e. where "package.json" lives. Default is '../..'
-    root = file("../../../")
+    root = file("../../../../")
     //   The folder where the react-native NPM package is. Default is ../../node_modules/react-native
-    reactNativeDir = file("../../../node_modules/react-native")
+    reactNativeDir = file("../../../../node_modules/react-native")
     //   The folder where the react-native Codegen package is. Default is ../../node_modules/@react-native/codegen
-    codegenDir = file("../../../node_modules/@react-native/codegen")
+    codegenDir = file("../../../../node_modules/@react-native/codegen")
     //   The cli.js file which is the React Native CLI entrypoint. Default is ../../node_modules/react-native/cli.js
-    cliFile = file("../../../node_modules/react-native/cli.js")
+    cliFile = file("../../../../node_modules/react-native/cli.js")
 
     /* Variants */
     //   The list of variants to that are debuggable. For those we're going to


### PR DESCRIPTION
### **User description**
## Problem

Both Mobile Build and Web Build CI pipelines are broken on main after the Turborepo monorepo migration (#73).

### Mobile Build
`build.gradle` at `apps/mobile/android/app/` used `../../../node_modules/` which resolves to `apps/node_modules/` (nonexistent). Needed `../../../../` to reach the project root where pnpm hoists packages.

Error:
```
Could not read script '.../apps/node_modules/react-native-vector-icons/fonts.gradle' as it does not exist.
```

### Web Build (Dependabot PRs)
Dependabot bumps mobile deps without regenerating `pnpm-lock.yaml`, causing `--frozen-lockfile` to fail. This is expected Dependabot behavior with pnpm monorepos — not a code bug. Dependabot PRs will need lockfile regen or a Dependabot config update separately.

## Changes

1. **`apps/mobile/android/app/build.gradle`** — Fixed all 5 `node_modules` path references from `../../../` to `../../../../` so they resolve from `apps/mobile/android/app/` → project root
   - `fonts.gradle` apply
   - `root` in react{} block
   - `reactNativeDir`, `codegenDir`, `cliFile`
2. **`.github/workflows/mobile.yml`** — Bumped `actions/setup-java` from v4 to v5

Note: `settings.gradle` paths were already correct (it's at `apps/mobile/android/`, one level higher).

## Verification

- ✅ All corrected paths verified to resolve to existing files in root `node_modules/`
- ✅ Web lint passes (4 warnings, 0 errors)
- ✅ Web tests pass (241 tests, 15 suites)
- ✅ Web build passes
- ⚠️ Android Gradle build not tested locally (no Android SDK on this machine) but path math is verified

Closes #87


___

### **PR Type**
Bug fix


___

### **Description**
- Bump `setup-java` action from v4 to v5


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mobile.yml</strong><dd><code>Bump setup-java action to v5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/mobile.yml

- Update `actions/setup-java` from v4 to v5


</details>


  </td>
  <td><a href="https://github.com/skynergroup/skystream/pull/88/files#diff-fba277883616717b49f01e1fa603c38c85603327832ed325c0688d0ee75f1162">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

