### PR TITLE
fix(player): migrate from Videasy to VidLink.pro #98

### DIFF
--- a/apps/web/src/components/StreamingPlayerModal.jsx
+++ b/apps/web/src/components/StreamingPlayerModal.jsx
@@ -8,8 +8,8 @@ import { updateBrowserUrl } from '../utils/urlRouting';
 
 import './StreamingPlayerModal.css';
 
-// Single player — Videasy handles all streaming
-const DEFAULT_SERVER = 'videasy';
+// Single player — VidLink handles all streaming
+const DEFAULT_SERVER = 'vidlink';
 
 const StreamingPlayerModal = ({
   isOpen,
@@ -124,22 +124,23 @@ const StreamingPlayerModal = ({
   useEffect(() => {
     if (!isOpen || contentType !== 'tv') return;
 
-    // Listen for postMessage from iframe about navigation
+    // Listen for postMessage from iframe about navigation.
+    // VidLink sends progress events shaped as:
+    //   { id, type, progress, timestamp, duration, season, episode }
     const handleMessage = event => {
-      const videasyOrigin = new URL(PLAYER_DEFAULTS.videasyBaseUrl).origin;
-      const allowedOrigins = [videasyOrigin, 'https://player.videasy.net', window.location.origin];
+      const vidlinkOrigin = new URL(PLAYER_DEFAULTS.playerBaseUrl).origin;
+      const allowedOrigins = [vidlinkOrigin, window.location.origin];
       if (!allowedOrigins.some(o => event.origin === o)) return;
 
-      if (event.data && event.data.type === 'episodeChange') {
+      // Update episode state whenever VidLink reports a new season/episode
+      if (event.data && event.data.season && event.data.episode) {
         const { season: newSeason, episode: newEpisode } = event.data;
-        if (newSeason && newEpisode) {
-          const seasonNum = Number.parseInt(newSeason, 10);
-          const episodeNum = Number.parseInt(newEpisode, 10);
+        const seasonNum = Number.parseInt(newSeason, 10);
+        const episodeNum = Number.parseInt(newEpisode, 10);
 
-          if (seasonNum !== selectedSeason || episodeNum !== selectedEpisode) {
-            setSelectedSeason(seasonNum);
-            setSelectedEpisode(episodeNum);
-          }
+        if (seasonNum !== selectedSeason || episodeNum !== selectedEpisode) {
+          setSelectedSeason(seasonNum);
+          setSelectedEpisode(episodeNum);
         }
       }
     };
@@ -287,7 +288,7 @@ const StreamingPlayerModal = ({
         <div className="streaming-player-modal__player">
           <iframe
             src={currentEmbedUrl}
-            title={`${content?.title} - Videasy`}
+            title={`${content?.title} - VidLink`}
             className={`streaming-player-modal__iframe ${iframeSwitching ? 'streaming-player-modal__iframe--loading' : 'streaming-player-modal__iframe--loaded'}`}
             allowFullScreen
             allow="encrypted-media; autoplay; fullscreen"
@@ -314,7 +315,7 @@ StreamingPlayerModal.propTypes = {
     id: PropTypes.number.isRequired,
     title: PropTypes.string,
   }),
-  platform: PropTypes.oneOf(['server1', 'server2', 'server3', 'videasy']),
+  platform: PropTypes.oneOf(['server1', 'server2', 'server3', 'vidlink', 'videasy']),
   embedUrl: PropTypes.string,
   contentType: PropTypes.oneOf(['movie', 'tv']),
   season: PropTypes.number,

--- a/apps/web/src/components/StreamingPlayerModal.jsx
+++ b/apps/web/src/components/StreamingPlayerModal.jsx
@@ -133,7 +133,7 @@ const StreamingPlayerModal = ({
       if (!allowedOrigins.some(o => event.origin === o)) return;
 
       // Update episode state whenever VidLink reports a new season/episode
-      if (event.data && event.data.season && event.data.episode) {
+      if (event.data && event.data.season != null && event.data.episode != null) {
         const { season: newSeason, episode: newEpisode } = event.data;
         const seasonNum = Number.parseInt(newSeason, 10);
         const episodeNum = Number.parseInt(newEpisode, 10);

--- a/apps/web/src/components/__tests__/StreamingPlayerModal.test.jsx
+++ b/apps/web/src/components/__tests__/StreamingPlayerModal.test.jsx
@@ -29,8 +29,11 @@ describe('StreamingPlayerModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     streamingServices.getAllStreamingUrls = jest.fn(() => ({
-      vidsrc: 'https://vidsrc.test/movie/1',
-      videasy: 'https://videasy.test/movie/1',
+      server1: 'https://vidlink.test/movie/1',
+      vidlink: 'https://vidlink.test/movie/1',
+      // Legacy aliases
+      videasy: 'https://vidlink.test/movie/1',
+      vidsrc: 'https://vidlink.test/movie/1',
     }));
     tmdbApi.getTVSeasonsData = jest.fn().mockResolvedValue({
       total_seasons: 2,
@@ -55,7 +58,7 @@ describe('StreamingPlayerModal', () => {
         isOpen={false}
         onClose={jest.fn()}
         content={mockContent}
-        platform="videasy"
+        platform="vidlink"
         embedUrl="https://test.com"
       />
     );
@@ -69,7 +72,7 @@ describe('StreamingPlayerModal', () => {
         isOpen={true}
         onClose={jest.fn()}
         content={mockContent}
-        platform="videasy"
+        platform="vidlink"
         embedUrl="https://test.com"
       />
     );
@@ -83,7 +86,7 @@ describe('StreamingPlayerModal', () => {
         isOpen={true}
         onClose={jest.fn()}
         content={mockContent}
-        platform="videasy"
+        platform="vidlink"
         embedUrl="https://test.com"
       />
     );
@@ -99,7 +102,7 @@ describe('StreamingPlayerModal', () => {
         isOpen={true}
         onClose={onClose}
         content={mockContent}
-        platform="videasy"
+        platform="vidlink"
         embedUrl="https://test.com"
       />
     );
@@ -114,7 +117,7 @@ describe('StreamingPlayerModal', () => {
         isOpen={true}
         onClose={jest.fn()}
         content={mockContent}
-        platform="videasy"
+        platform="vidlink"
         embedUrl="https://test.com"
       />
     );
@@ -129,7 +132,7 @@ describe('StreamingPlayerModal', () => {
         isOpen={true}
         onClose={jest.fn()}
         content={mockTVContent}
-        platform="videasy"
+        platform="vidlink"
         embedUrl="https://test.com"
         contentType="tv"
       />
@@ -146,7 +149,7 @@ describe('StreamingPlayerModal', () => {
         isOpen={true}
         onClose={jest.fn()}
         content={mockTVContent}
-        platform="videasy"
+        platform="vidlink"
         embedUrl="https://test.com"
         contentType="tv"
       />
@@ -164,7 +167,7 @@ describe('StreamingPlayerModal', () => {
         isOpen={true}
         onClose={jest.fn()}
         content={mockTVContent}
-        platform="videasy"
+        platform="vidlink"
         embedUrl="https://test.com"
         contentType="tv"
         season={1}
@@ -190,7 +193,7 @@ describe('StreamingPlayerModal', () => {
         isOpen={true}
         onClose={jest.fn()}
         content={mockTVContent}
-        platform="videasy"
+        platform="vidlink"
         embedUrl="https://test.com"
         contentType="tv"
         season={1}
@@ -218,7 +221,7 @@ describe('StreamingPlayerModal', () => {
         isOpen={true}
         onClose={jest.fn()}
         content={mockTVContent}
-        platform="videasy"
+        platform="vidlink"
         embedUrl="https://test.com"
         contentType="tv"
       />
@@ -238,7 +241,7 @@ describe('StreamingPlayerModal', () => {
         isOpen={false}
         onClose={jest.fn()}
         content={mockTVContent}
-        platform="videasy"
+        platform="vidlink"
         embedUrl="https://test.com"
         contentType="tv"
         season={2}
@@ -251,7 +254,7 @@ describe('StreamingPlayerModal', () => {
         isOpen={true}
         onClose={jest.fn()}
         content={mockTVContent}
-        platform="videasy"
+        platform="vidlink"
         embedUrl="https://test.com"
         contentType="tv"
         season={2}
@@ -268,7 +271,7 @@ describe('StreamingPlayerModal', () => {
         isOpen={true}
         onClose={jest.fn()}
         content={null}
-        platform="videasy"
+        platform="vidlink"
         embedUrl="https://fallback.com"
       />
     );

--- a/apps/web/src/services/__tests__/streamingServices.test.js
+++ b/apps/web/src/services/__tests__/streamingServices.test.js
@@ -1,27 +1,30 @@
 import streamingServices from '../streamingServices';
 import { PLAYER_DEFAULTS } from '@skystream/shared';
 
-const BASE = PLAYER_DEFAULTS.videasyBaseUrl;
+const BASE = PLAYER_DEFAULTS.playerBaseUrl;
 
-describe('StreamingServices (Videasy)', () => {
+describe('StreamingServices (VidLink)', () => {
   describe('getMovieUrl', () => {
     it('generates basic movie URL', () => {
       const url = streamingServices.getMovieUrl(299534);
       expect(url).toContain(`${BASE}/movie/299534`);
     });
 
-    it('includes default color and overlay', () => {
+    it('includes default primaryColor, poster, and title', () => {
       const url = streamingServices.getMovieUrl(299534);
-      expect(url).toContain('color=e50914');
-      expect(url).toContain('overlay=true');
+      expect(url).toContain('primaryColor=e50914');
+      expect(url).toContain('poster=true');
+      expect(url).toContain('title=true');
+      // Videasy overlay param must not bleed through
+      expect(url).not.toContain('overlay=');
     });
 
-    it('accepts custom options', () => {
+    it('accepts custom color (legacy param) and progress', () => {
       const url = streamingServices.getMovieUrl(299534, {
         color: '3B82F6',
         progress: 60,
       });
-      expect(url).toContain('color=3B82F6');
+      expect(url).toContain('primaryColor=3B82F6');
       expect(url).toContain('progress=60');
     });
   });
@@ -32,11 +35,14 @@ describe('StreamingServices (Videasy)', () => {
       expect(url).toContain(`${BASE}/tv/1399/2/5`);
     });
 
-    it('includes episode navigation features by default', () => {
+    it('uses nextbutton (not nextEpisode) and omits removed Videasy params', () => {
       const url = streamingServices.getTVUrl(1399, 1, 1);
-      expect(url).toContain('nextEpisode=true');
-      expect(url).toContain('episodeSelector=true');
-      expect(url).toContain('autoplayNextEpisode=true');
+      expect(url).toContain('nextbutton=true');
+      expect(url).toContain('poster=true');
+      expect(url).toContain('title=true');
+      expect(url).not.toContain('episodeSelector=');
+      expect(url).not.toContain('autoplayNextEpisode=');
+      expect(url).not.toContain('overlay=');
     });
 
     it('defaults to season 1 episode 1', () => {
@@ -46,14 +52,15 @@ describe('StreamingServices (Videasy)', () => {
   });
 
   describe('getAnimeUrl', () => {
-    it('generates anime URL with episode', () => {
+    it('generates anime URL with episode (defaults to sub)', () => {
       const url = streamingServices.getAnimeUrl(21, 5);
-      expect(url).toContain(`${BASE}/anime/21/5`);
+      expect(url).toContain(`${BASE}/anime/21/5/sub`);
     });
 
-    it('supports dub option', () => {
+    it('supports dub option (backward-compat boolean → path segment)', () => {
       const url = streamingServices.getAnimeUrl(21, 1, { dub: true });
-      expect(url).toContain('dub=true');
+      expect(url).toContain('/dub');
+      expect(url).not.toContain('/sub');
     });
   });
 
@@ -73,20 +80,22 @@ describe('StreamingServices (Videasy)', () => {
   });
 
   describe('getAllStreamingUrls', () => {
-    it('returns Videasy URL with legacy aliases for movies', () => {
+    it('returns VidLink URL with legacy aliases for movies', () => {
       const urls = streamingServices.getAllStreamingUrls({ id: 299534, type: 'movie' });
-      expect(urls.videasy).toContain(`${BASE}/movie/299534`);
-      expect(urls.server1).toBe(urls.videasy);
-      expect(urls.vidsrc).toBe(urls.videasy);
+      expect(urls.server1).toContain(`${BASE}/movie/299534`);
+      expect(urls.vidlink).toBe(urls.server1);
+      // Legacy aliases still present for backward compat
+      expect(urls.videasy).toBe(urls.server1);
+      expect(urls.vidsrc).toBe(urls.server1);
     });
 
-    it('returns Videasy URL with legacy aliases for TV', () => {
+    it('returns VidLink URL with legacy aliases for TV', () => {
       const urls = streamingServices.getAllStreamingUrls(
         { id: 1399, type: 'tv' },
         { season: 1, episode: 1 }
       );
-      expect(urls.videasy).toContain(`${BASE}/tv/1399/1/1`);
-      expect(urls.server1).toBe(urls.videasy);
+      expect(urls.server1).toContain(`${BASE}/tv/1399/1/1`);
+      expect(urls.vidlink).toBe(urls.server1);
     });
   });
 

--- a/packages/api/src/__tests__/StreamingServices.test.js
+++ b/packages/api/src/__tests__/StreamingServices.test.js
@@ -69,12 +69,11 @@ describe('StreamingServices (VidLink)', () => {
       expect(url).toContain('/dub');
     });
 
-    it('generates anime movie URL (no episode)', () => {
+    it('generates anime movie URL (no episode, no audio track)', () => {
       const url = streamingServices.getAnimeUrl(145139, 0);
-      expect(url).toContain(`${BASE}/anime/145139`);
+      expect(url).toBe(`${BASE}/anime/145139`);
       expect(url).not.toContain('/0');
-      // Sub/dub segment still present
-      expect(url).toMatch(/\/(sub|dub)$/);
+      expect(url).not.toMatch(/\/(sub|dub)/);
     });
   });
 

--- a/packages/api/src/__tests__/StreamingServices.test.js
+++ b/packages/api/src/__tests__/StreamingServices.test.js
@@ -1,21 +1,30 @@
 import streamingServices from '../streaming/StreamingServices.js';
 import { PLAYER_DEFAULTS } from '@skystream/shared';
 
-const BASE = PLAYER_DEFAULTS.videasyBaseUrl;
+const BASE = PLAYER_DEFAULTS.playerBaseUrl;
 
-describe('StreamingServices (Videasy)', () => {
+describe('StreamingServices (VidLink)', () => {
   describe('getMovieUrl', () => {
     it('generates a movie URL with default options', () => {
       const url = streamingServices.getMovieUrl(550);
       expect(url).toContain(`${BASE}/movie/550`);
-      expect(url).toContain('color=e50914');
-      expect(url).toContain('overlay=true');
+      expect(url).toContain('primaryColor=e50914');
+      expect(url).toContain('poster=true');
+      expect(url).toContain('title=true');
+      // Videasy overlay param must not bleed through
+      expect(url).not.toContain('overlay=');
     });
 
-    it('accepts custom color and progress', () => {
+    it('accepts custom color (legacy param) and progress', () => {
       const url = streamingServices.getMovieUrl(550, { color: '3B82F6', progress: 120 });
-      expect(url).toContain('color=3B82F6');
+      expect(url).toContain('primaryColor=3B82F6');
       expect(url).toContain('progress=120');
+    });
+
+    it('prefers explicit primaryColor over legacy color', () => {
+      const url = streamingServices.getMovieUrl(550, { primaryColor: 'FF0000', color: '3B82F6' });
+      expect(url).toContain('primaryColor=FF0000');
+      expect(url).not.toContain('primaryColor=3B82F6');
     });
   });
 
@@ -23,32 +32,49 @@ describe('StreamingServices (Videasy)', () => {
     it('generates a TV URL with season and episode', () => {
       const url = streamingServices.getTVUrl(1399, 2, 5);
       expect(url).toContain(`${BASE}/tv/1399/2/5`);
-      expect(url).toContain('nextEpisode=true');
-      expect(url).toContain('episodeSelector=true');
-      expect(url).toContain('autoplayNextEpisode=true');
+      expect(url).toContain('nextbutton=true');
+      expect(url).toContain('poster=true');
+      expect(url).toContain('title=true');
+      // Removed Videasy-only params
+      expect(url).not.toContain('episodeSelector=');
+      expect(url).not.toContain('autoplayNextEpisode=');
+      expect(url).not.toContain('overlay=');
     });
 
     it('defaults to season 1 episode 1', () => {
       const url = streamingServices.getTVUrl(1399);
       expect(url).toContain('/tv/1399/1/1');
     });
+
+    it('supports explicit nextbutton param', () => {
+      const url = streamingServices.getTVUrl(1399, 1, 1, { nextbutton: false });
+      expect(url).not.toContain('nextbutton=');
+    });
   });
 
   describe('getAnimeUrl', () => {
-    it('generates an anime URL with episode', () => {
+    it('generates an anime URL with episode (defaults to sub)', () => {
       const url = streamingServices.getAnimeUrl(21, 5);
-      expect(url).toContain(`${BASE}/anime/21/5`);
+      expect(url).toContain(`${BASE}/anime/21/5/sub`);
     });
 
-    it('supports dub option', () => {
+    it('supports dub option (backward-compat boolean)', () => {
       const url = streamingServices.getAnimeUrl(21, 1, { dub: true });
-      expect(url).toContain('dub=true');
+      expect(url).toContain('/dub');
+      expect(url).not.toContain('/sub');
+    });
+
+    it('supports explicit subOrDub path segment', () => {
+      const url = streamingServices.getAnimeUrl(21, 1, { subOrDub: 'dub' });
+      expect(url).toContain('/dub');
     });
 
     it('generates anime movie URL (no episode)', () => {
       const url = streamingServices.getAnimeUrl(145139, 0);
       expect(url).toContain(`${BASE}/anime/145139`);
       expect(url).not.toContain('/0');
+      // Sub/dub segment still present
+      expect(url).toMatch(/\/(sub|dub)$/);
     });
   });
 
@@ -73,15 +99,17 @@ describe('StreamingServices (Videasy)', () => {
   });
 
   describe('getAllStreamingUrls', () => {
-    it('returns Videasy URL with legacy aliases for a movie', () => {
+    it('returns VidLink URL with legacy aliases for a movie', () => {
       const urls = streamingServices.getAllStreamingUrls({ id: 550, type: 'movie' });
 
       expect(urls.server1).toContain(`${BASE}/movie/550`);
+      expect(urls.vidlink).toBe(urls.server1);
+      // Legacy aliases still present for backward compat
       expect(urls.videasy).toBe(urls.server1);
       expect(urls.vidsrc).toBe(urls.server1);
     });
 
-    it('returns Videasy URL with season/episode for TV', () => {
+    it('returns VidLink URL with season/episode for TV', () => {
       const urls = streamingServices.getAllStreamingUrls(
         { id: 1399, type: 'tv' },
         { season: 1, episode: 1 }

--- a/packages/api/src/streaming/StreamingServices.js
+++ b/packages/api/src/streaming/StreamingServices.js
@@ -1,29 +1,35 @@
 /**
  * Streaming Services API
- * Handles embed URL generation for Videasy player
- * Docs: https://www.videasy.to/docs
+ * Handles embed URL generation for VidLink.pro player
+ * Docs: https://vidlink.pro
  */
 
 import { PLAYER_DEFAULTS } from '@skystream/shared';
 
 class StreamingServices {
   constructor() {
-    this.videasyDomain = PLAYER_DEFAULTS.videasyBaseUrl;
+    this.playerDomain = PLAYER_DEFAULTS.playerBaseUrl;
+    // Backward-compat alias
+    this.videasyDomain = this.playerDomain;
   }
 
   /**
-   * Generate Videasy embed URL for movies
+   * Generate VidLink embed URL for movies
+   * https://vidlink.pro/movie/{tmdbId}?primaryColor=e50914&autoplay=true&poster=true&title=true
    */
   getMovieUrl(tmdbId, options = {}) {
-    const { color = 'e50914', progress, overlay = true, autoplay = 1 } = options;
+    const { primaryColor, color = 'e50914', progress, autoplay = true } = options;
+    // Support legacy 'color' param — primaryColor takes precedence
+    const resolvedColor = primaryColor || color;
 
-    let url = `${this.videasyDomain}/movie/${tmdbId}`;
+    let url = `${this.playerDomain}/movie/${tmdbId}`;
 
     const params = new URLSearchParams();
-    if (color) params.append('color', color);
+    if (resolvedColor) params.append('primaryColor', resolvedColor);
     if (progress) params.append('progress', progress);
-    if (overlay) params.append('overlay', 'true');
-    if (autoplay !== undefined) params.append('autoplay', autoplay);
+    params.append('autoplay', autoplay ? 'true' : String(autoplay));
+    params.append('poster', 'true');
+    params.append('title', 'true');
 
     const queryString = params.toString();
     if (queryString) url += `?${queryString}`;
@@ -32,27 +38,32 @@ class StreamingServices {
   }
 
   /**
-   * Generate Videasy embed URL for TV shows
+   * Generate VidLink embed URL for TV shows
+   * https://vidlink.pro/tv/{tmdbId}/{season}/{episode}?primaryColor=e50914&nextbutton=true&autoplay=true&poster=true&title=true
    */
   getTVUrl(tmdbId, season = 1, episode = 1, options = {}) {
     const {
+      primaryColor,
       color = 'e50914',
       progress,
+      // 'nextEpisode' is the legacy Videasy param; 'nextbutton' is the VidLink param.
+      // nextbutton takes precedence; nextEpisode falls back for callers that haven't migrated yet.
       nextEpisode = true,
-      episodeSelector = true,
-      autoplayNextEpisode = true,
-      overlay = true,
+      nextbutton,
+      autoplay = true,
     } = options;
+    const resolvedColor = primaryColor || color;
+    const resolvedNextbutton = nextbutton !== undefined ? nextbutton : nextEpisode;
 
-    let url = `${this.videasyDomain}/tv/${tmdbId}/${season}/${episode}`;
+    let url = `${this.playerDomain}/tv/${tmdbId}/${season}/${episode}`;
 
     const params = new URLSearchParams();
-    if (color) params.append('color', color);
+    if (resolvedColor) params.append('primaryColor', resolvedColor);
     if (progress) params.append('progress', progress);
-    if (nextEpisode) params.append('nextEpisode', 'true');
-    if (episodeSelector) params.append('episodeSelector', 'true');
-    if (autoplayNextEpisode) params.append('autoplayNextEpisode', 'true');
-    if (overlay) params.append('overlay', 'true');
+    if (resolvedNextbutton) params.append('nextbutton', 'true');
+    params.append('autoplay', autoplay ? 'true' : String(autoplay));
+    params.append('poster', 'true');
+    params.append('title', 'true');
 
     const queryString = params.toString();
     if (queryString) url += `?${queryString}`;
@@ -61,33 +72,22 @@ class StreamingServices {
   }
 
   /**
-   * Generate Videasy embed URL for anime
+   * Generate VidLink embed URL for anime
+   * https://vidlink.pro/anime/{MALid}/{number}/{subOrDub}
+   *
+   * @param {number} malId  - MyAnimeList ID
+   * @param {number} episode - Episode number (0 = anime movie, omits episode segment)
+   * @param {object} options
+   * @param {boolean} [options.dub=false]   - Backward-compat: true maps to 'dub', false to 'sub'
+   * @param {string}  [options.subOrDub]    - Explicit 'sub' | 'dub' override (takes precedence)
    */
-  getAnimeUrl(anilistId, episode = 1, options = {}) {
-    const {
-      dub = false,
-      color = 'e50914',
-      progress,
-      nextEpisode = true,
-      episodeSelector = true,
-      autoplayNextEpisode = true,
-      overlay = true,
-    } = options;
+  getAnimeUrl(malId, episode = 1, options = {}) {
+    const { dub = false, subOrDub } = options;
+    const audioTrack = subOrDub || (dub ? 'dub' : 'sub');
 
-    let url = `${this.videasyDomain}/anime/${anilistId}`;
+    let url = `${this.playerDomain}/anime/${malId}`;
     if (episode > 0) url += `/${episode}`;
-
-    const params = new URLSearchParams();
-    if (dub) params.append('dub', 'true');
-    if (color) params.append('color', color);
-    if (progress) params.append('progress', progress);
-    if (nextEpisode) params.append('nextEpisode', 'true');
-    if (episodeSelector) params.append('episodeSelector', 'true');
-    if (autoplayNextEpisode) params.append('autoplayNextEpisode', 'true');
-    if (overlay) params.append('overlay', 'true');
-
-    const queryString = params.toString();
-    if (queryString) url += `?${queryString}`;
+    url += `/${audioTrack}`;
 
     return url;
   }
@@ -108,7 +108,7 @@ class StreamingServices {
   }
 
   // ---- Legacy compatibility aliases ----
-  // These map old method names to the Videasy equivalents so existing
+  // These map old Videasy method names to VidLink equivalents so existing
   // callers (web components, mobile screens) keep working without changes.
 
   getVideasyMovieUrl(tmdbId, options = {}) {
@@ -119,21 +119,22 @@ class StreamingServices {
     return this.getTVUrl(tmdbId, season, episode, options);
   }
 
-  getVideasyAnimeUrl(anilistId, episode = 1, options = {}) {
-    return this.getAnimeUrl(anilistId, episode, options);
+  getVideasyAnimeUrl(malId, episode = 1, options = {}) {
+    return this.getAnimeUrl(malId, episode, options);
   }
 
   /**
-   * Get all available streaming URLs for a content item
-   * Returns a single Videasy URL with legacy key aliases for backward compat
+   * Get all available streaming URLs for a content item.
+   * Returns a single VidLink URL with legacy key aliases for backward compat.
    */
   getAllStreamingUrls(content, options = {}) {
     const url = this.getStreamingUrl(content, options);
 
     return {
       server1: url,
-      videasy: url,
+      vidlink: url,
       // Legacy aliases
+      videasy: url,
       vidsrc: url,
     };
   }

--- a/packages/api/src/streaming/StreamingServices.js
+++ b/packages/api/src/streaming/StreamingServices.js
@@ -27,7 +27,7 @@ class StreamingServices {
     const params = new URLSearchParams();
     if (resolvedColor) params.append('primaryColor', resolvedColor);
     if (progress) params.append('progress', progress);
-    params.append('autoplay', autoplay ? 'true' : String(autoplay));
+    if (autoplay) params.append('autoplay', 'true');
     params.append('poster', 'true');
     params.append('title', 'true');
 
@@ -61,7 +61,7 @@ class StreamingServices {
     if (resolvedColor) params.append('primaryColor', resolvedColor);
     if (progress) params.append('progress', progress);
     if (resolvedNextbutton) params.append('nextbutton', 'true');
-    params.append('autoplay', autoplay ? 'true' : String(autoplay));
+    if (autoplay) params.append('autoplay', 'true');
     params.append('poster', 'true');
     params.append('title', 'true');
 
@@ -86,8 +86,9 @@ class StreamingServices {
     const audioTrack = subOrDub || (dub ? 'dub' : 'sub');
 
     let url = `${this.playerDomain}/anime/${malId}`;
-    if (episode > 0) url += `/${episode}`;
-    url += `/${audioTrack}`;
+    if (episode > 0) {
+      url += `/${episode}/${audioTrack}`;
+    }
 
     return url;
   }

--- a/packages/shared/src/__tests__/config.test.js
+++ b/packages/shared/src/__tests__/config.test.js
@@ -56,9 +56,9 @@ describe('shared config', () => {
       expect(TMDB_DEFAULTS.defaultBackdropSize).toBe('w1280');
     });
 
-    it('PLAYER_DEFAULTS exposes the Videasy URL and defaults', () => {
-      expect(PLAYER_DEFAULTS.videasyBaseUrl).toMatch(/videasy/);
-      expect(PLAYER_DEFAULTS.defaultPlayer).toBe('videasy');
+    it('PLAYER_DEFAULTS exposes the VidLink URL and defaults', () => {
+      expect(PLAYER_DEFAULTS.videasyBaseUrl).toBe('https://vidlink.pro');
+      expect(PLAYER_DEFAULTS.defaultPlayer).toBe('vidlink');
       expect(PLAYER_DEFAULTS.defaultColor).toBe('e50914');
     });
   });

--- a/packages/shared/src/config/index.js
+++ b/packages/shared/src/config/index.js
@@ -12,8 +12,10 @@ export const TMDB_DEFAULTS = {
 };
 
 export const PLAYER_DEFAULTS = {
-  videasyBaseUrl: 'https://player.videasy.to',
-  defaultPlayer: 'videasy',
+  playerBaseUrl: 'https://vidlink.pro',
+  // Backward-compat alias — consumers that still reference videasyBaseUrl keep working
+  videasyBaseUrl: 'https://vidlink.pro',
+  defaultPlayer: 'vidlink',
   defaultColor: 'e50914',
   autoPlay: true,
   language: 'en',


### PR DESCRIPTION
### **User description**
## Summary

- **Removes Videasy** (`player.videasy.to`) — ad overlays were hijacking the first click and opening sketchy tabs.
- **Migrates to VidLink.pro** — no ads, same TMDB ID structure, confirmed working with identical content.
- All URL params updated to VidLink spec (`primaryColor`, `nextbutton`, `poster`, `title`; removed `overlay`, `episodeSelector`, `autoplayNextEpisode`).
- Anime URLs now use the VidLink path-based `/{sub|dub}` segment instead of a query param.
- `postMessage` allowlist updated to `https://vidlink.pro`; handler updated for VidLink's progress-event shape.
- **Backward compat preserved throughout**: `videasyBaseUrl` alias in config, `getVideasy*` method aliases in `StreamingServices`, `videasy`/`vidsrc` keys in `getAllStreamingUrls`.

## Files changed

| File | Change |
|---|---|
| `packages/shared/src/config/index.js` | Add `playerBaseUrl`, keep `videasyBaseUrl` alias, rename `defaultPlayer` |
| `packages/api/src/streaming/StreamingServices.js` | Rewrite URL builders for VidLink params |
| `apps/web/src/components/StreamingPlayerModal.jsx` | Update iframe title, postMessage origins/handler |
| `packages/api/src/__tests__/StreamingServices.test.js` | Assert VidLink params & domain |
| `apps/web/src/services/__tests__/streamingServices.test.js` | Assert VidLink params & domain |
| `apps/web/src/components/__tests__/StreamingPlayerModal.test.jsx` | Update platform refs and mock URLs |

## Test plan

- [x] `pnpm --filter @skystream/api test` — 36/36 pass
- [x] `pnpm --filter web test` — 241/241 pass
- [x] `turbo run lint` — 0 errors (4 pre-existing warnings, all pre-migration)
- [ ] Manual smoke: open a movie/show in the player and confirm no ad overlay on first click
- [ ] Verify next-episode button works in TV series

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Migrate video player from Videasy to VidLink.pro

- Remove ad overlays and fix first-click hijacking

- Update URL params to VidLink API spec

- Add anime support with MAL IDs and sub/dub paths

- Preserve backward compatibility via aliases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Videasy player<br/>player.videasy.to"] -->|"ad overlay hijacks clicks"| B["Broken UX"]
  C["VidLink.pro<br/>vidlink.pro"] -->|"no ads, same TMDB structure"| D["Fixed UX"]
  B -->|"migrate"| D
  E["Legacy code"] -->|"backward-compat aliases"| D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>Add VidLink base URL with Videasy backward compat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/shared/src/config/index.js

<ul><li>Add <code>playerBaseUrl</code> pointing to <code>https://vidlink.pro</code><br> <li> Keep <code>videasyBaseUrl</code> as backward-compat alias to same URL<br> <li> Change <code>defaultPlayer</code> from <code>'videasy'</code> to <code>'vidlink'</code></ul>


</details>


  </td>
  <td><a href="https://github.com/yashiels/skystream/pull/100/files#diff-94f8cf6cec83086142862c033c4a4394ed18d7b00228b6da97fdab24385a7716">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StreamingServices.js</strong><dd><code>Rewrite URL builders for VidLink API with legacy aliases</code>&nbsp; </dd></summary>
<hr>

packages/api/src/streaming/StreamingServices.js

<ul><li>Rewrite <code>getMovieUrl</code> with <code>primaryColor</code>, <code>poster</code>, <code>title</code>; remove <code>overlay</code><br> <li> Rewrite <code>getTVUrl</code> with <code>nextbutton</code> instead of <code>nextEpisode</code>; remove <br><code>episodeSelector</code> and <code>autoplayNextEpisode</code><br> <li> Rewrite <code>getAnimeUrl</code> to use path-based <code>/{sub|dub}</code> segment with MAL IDs <br>instead of AniList IDs<br> <li> Add legacy param fallback: <code>color</code> → <code>primaryColor</code>, <code>nextEpisode</code> → <br><code>nextbutton</code><br> <li> Update <code>getAllStreamingUrls</code> to expose <code>vidlink</code> key with legacy <br><code>videasy</code>/<code>vidsrc</code> aliases<br> <li> Preserve <code>getVideasy*</code> method aliases for existing callers</ul>


</details>


  </td>
  <td><a href="https://github.com/yashiels/skystream/pull/100/files#diff-df1c646ed954df2b4b40a32cbaaf3914d93a98d9824083a568812507257d0f48">+50/-49</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StreamingPlayerModal.jsx</strong><dd><code>Update player modal for VidLink postMessage and branding</code>&nbsp; </dd></summary>
<hr>

apps/web/src/components/StreamingPlayerModal.jsx

<ul><li>Change default server from <code>'videasy'</code> to <code>'vidlink'</code><br> <li> Update iframe title from <code>Videasy</code> to <code>VidLink</code><br> <li> Replace <code>player.videasy.net</code> with <code>vidlink.pro</code> in postMessage origin <br>allowlist<br> <li> Update postMessage handler to check for <code>season</code>/<code>episode</code> fields instead <br>of <code>episodeChange</code> type<br> <li> Add <code>'vidlink'</code> to <code>platform</code> PropTypes</ul>


</details>


  </td>
  <td><a href="https://github.com/yashiels/skystream/pull/100/files#diff-7b4447e33c65a3cd5eb4a3ce3f81f70a34437ee264549e2d080dbde97161cc9e">+17/-16</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StreamingServices.test.js</strong><dd><code>Update API tests for VidLink params and anime paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/api/src/__tests__/StreamingServices.test.js

<ul><li>Update all test descriptions from <code>Videasy</code> to <code>VidLink</code><br> <li> Assert <code>primaryColor</code>, <code>poster</code>, <code>title</code> params; deny <code>overlay</code><br> <li> Assert <code>nextbutton</code> instead of <code>nextEpisode</code>; deny removed params<br> <li> Add tests for <code>primaryColor</code> precedence over legacy <code>color</code><br> <li> Add tests for anime sub/dub path segments and <code>subOrDub</code> option<br> <li> Assert <code>vidlink</code> key in <code>getAllStreamingUrls</code> with legacy aliases</ul>


</details>


  </td>
  <td><a href="https://github.com/yashiels/skystream/pull/100/files#diff-40a8bc2b9e66edb7e25aa41b249fba02830556d052234ac1addf5e60046afbf7">+43/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>streamingServices.test.js</strong><dd><code>Update web service tests for VidLink migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/services/__tests__/streamingServices.test.js

<ul><li>Update base URL from <code>videasyBaseUrl</code> to <code>playerBaseUrl</code><br> <li> Update test descriptions from <code>Videasy</code> to <code>VidLink</code><br> <li> Assert <code>primaryColor</code>, <code>poster</code>, <code>title</code>; deny <code>overlay</code><br> <li> Assert <code>nextbutton</code> instead of <code>nextEpisode</code>; deny removed params<br> <li> Assert anime defaults to <code>sub</code> path, <code>dub</code> boolean maps to path segment<br> <li> Assert <code>vidlink</code> key with legacy <code>videasy</code>/<code>vidsrc</code> aliases</ul>


</details>


  </td>
  <td><a href="https://github.com/yashiels/skystream/pull/100/files#diff-562860ff1137fc2b0f7702a899f98a3267d8a367a98e5b4ba037206f6a7817fd">+31/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>StreamingPlayerModal.test.jsx</strong><dd><code>Update modal tests for VidLink platform references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/__tests__/StreamingPlayerModal.test.jsx

<ul><li>Update mock URLs from <code>vidsrc</code>/<code>videasy</code> to <code>vidlink</code> with legacy aliases<br> <li> Change all <code>platform="videasy"</code> props to <code>platform="vidlink"</code><br> <li> Update mock <code>getAllStreamingUrls</code> return to include <code>server1</code>/<code>vidlink</code> keys</ul>


</details>


  </td>
  <td><a href="https://github.com/yashiels/skystream/pull/100/files#diff-3357a462685a1d3c995c1783b79aff30ce77b1484470e26f9a2532d2c2a9f0e3">+18/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

