### PR TITLE
chore(ci): pin pr-agent to skynergroup/.github@main

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -10,6 +10,6 @@ permissions:
   contents: read
 jobs:
   review:
-    uses: skynergroup/.github/.github/workflows/pr-agent.yml@ce7ff12890df7f371e0f5cae0273359cdff3e235
+    uses: skynergroup/.github/.github/workflows/pr-agent.yml
     secrets:
       KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}


### PR DESCRIPTION
Repoint pr-agent caller from a pinned SHA to skynergroup/.github@main for real-time updates. Shared workflow bakes in ai_timeout=600 and max_model_tokens=200000. Key stays repo-level (org-level secret for skynergroup repos).