### PR TITLE
chore(ci): add @main ref to pr-agent workflow

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -10,6 +10,5 @@ permissions:
   contents: read
 jobs:
   review:
-    uses: skynergroup/.github/.github/workflows/pr-agent.yml
-    secrets:
+    uses: skynergroup/.github/.github/workflows/pr-agent.yml@main    secrets:
       KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}


### PR DESCRIPTION
Fix: previous merge dropped the @main ref due to a script bug. This restores it.